### PR TITLE
Add HUAK_MUTE_SUBCOMMAND env var

### DIFF
--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -48,4 +48,5 @@ jobs:
             cargo clippy -- -D warnings
       - name: Run tests
         run: |
-          cargo test --all-features -- --test-threads=1
+          HUAK_MUTE_SUBCOMAND=1 \
+            cargo test --all-features -- --test-threads=1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,15 @@ You can reach out to me on discord at cnpryer#6201 if you have any questions. Ot
 
 ## Testing
 
-During the early stages of Huak's development, we'll use `cargo test -- --test-threads=1` to allow manipulation of one .venv. An issue to improve on this in the future has been opened at #123. This is set in .cargo/config.toml as well.
+During the early stages of Huak's development, we'll use `cargo test -- --test-threads=1` to allow manipulation of one .venv. An issue to improve on this in the future has been opened at #123.
+
+Since we are using a hacky .venv testing strategy, you'll want to run tests using a `HUAK_MUTE_SUBCOMMAND` environment variable.
+
+We set `--test-threads=1` in .cargo/config.toml so we can just run:
+
+```console
+$ HUAK_MUTE_SUBCOMMAND=True cargo test
+```
 
 ## Making a contribution
 

--- a/src/huak/utils/command.rs
+++ b/src/huak/utils/command.rs
@@ -1,10 +1,50 @@
-use std::{path::Path, process};
+use std::{env, path::Path, process};
 
 use crate::errors::CliError;
 
 /// Run a command using process::Command and an array of args. The command will
-/// execute inside a `from` dir.
+/// execute inside a `from` dir. Set the environment variable
+/// HUAK_MUTE_SUBCOMMAND to True to mute subcommand stdout.
 pub(crate) fn run_command(
+    cmd: &str,
+    args: &[&str],
+    from: &Path,
+) -> Result<i32, CliError> {
+    match should_mute() {
+        true => run_command_with_output(cmd, args, from),
+        false => run_command_with_spawn(cmd, args, from),
+    }
+}
+
+/// Mute command utilities with HUAK_MUTE_SUBCOMMAND ("True", "true").
+fn should_mute() -> bool {
+    let _mute = match env::var("HUAK_MUTE_SUBCOMMAND") {
+        Ok(m) => m,
+        Err(_) => "False".to_string(),
+    };
+
+    matches!(_mute.as_str(), "TRUE" | "True" | "true" | "1")
+}
+
+/// Run initilized command with .output() to mute stdout.
+fn run_command_with_output(
+    cmd: &str,
+    args: &[&str],
+    from: &Path,
+) -> Result<i32, CliError> {
+    let output = process::Command::new(cmd)
+        .args(args)
+        .current_dir(from)
+        .output()?;
+
+    let status = output.status;
+
+    Ok(status.code().unwrap_or_default())
+}
+
+/// Run a command using process::Command and an array of args. The command will
+/// execute inside a `from` dir.
+pub(crate) fn run_command_with_spawn(
     cmd: &str,
     args: &[&str],
     from: &Path,


### PR DESCRIPTION
Closes #147 

## Summary of changes

    - Add `should_mute` function.
    - Match on environment var result
    - Split command into _output and _spawn helpers
