### PR TITLE
Start a v0.0.2-alpha.1 for docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huak"
-version = "0.0.1"
+version = "0.0.2-alpha.1"
 edition = "2021"
 license = "MIT"
 description = "A Python package manager written in Rust inspired by Cargo."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![ci-rust](https://github.com/cnpryer/huak/actions/workflows/ci-rust.yaml/badge.svg)](https://github.com/cnpryer/huak/actions/workflows/ci-rust.yaml)
 [![ci-python](https://github.com/cnpryer/huak/actions/workflows/ci-python.yaml/badge.svg)](https://github.com/cnpryer/huak/actions/workflows/ci-python.yaml)
+[![crates.io](https://img.shields.io/crates/v/huak.svg)](https://crates.io/crates/huak)
 
 # huak
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ _"**" indicates incomplete first-pass but planned for 0.1.x_
 
 ## Documentation
 
+If you've cloned the repository, run `cargo doc --open`.
+
 Some documentation for 0.0.x releases will land on docs.rs. Around the 0.1.0 release I'd like to have more robust documentation about Huak for users, contributors, and the curious.
 
 ## Goals

--- a/src/huak/lib.rs
+++ b/src/huak/lib.rs
@@ -1,40 +1,110 @@
-//! A Python package manager written in Rust. The [Cargo](https://github.com/rust-lang/cargo) for Python.
+//! ## About
 //!
-//! See either [this milestone list](https://github.com/cnpryer/huak/milestones) or [the issue board](https://github.com/users/cnpryer/projects/5) to check the status of this project at any point in time.
-//!
-//! - [Goals and Motivation](#goals)
-//! - [Contributing](#contributing)
-//! - [Architecture and Design](#architecture-and-design)
-//!
-//! ## Goals
-//!
-//! There are a few guiding principles steering the development of Huak:
-//!
-//! ### 1. Serve as a learning instrument 📚
-//!
-//! - Python packaging is a very interesting topic right now.
-//! - It's challenging and dev tools are some of my favorite products, I'm curious of how they work.
-//! - Learn Rust and about building fast, snappy, and opinionated software.
-//!
-//! ### 2. Just use `huak` ✨
-//!
-//! I love Rust's onboarding experience. Cargo has played a large role. It's a great tool for newcomers to use to get their feet wet. Huak can provide the same experience for Python.
-//!
-//! ### 3. Fast ⚡️
-//!
-//! There's room for faster tooling in the Python ecosystem. One of the guiding principles will be "Is this the fastest it can be?"
-//!
-//! ### 4. Python 🤝 Rust
-//!
-//! JavaScript has seen a "Going Rust" sub-community pop up. Python seems to be getting one too. Huak would be able to fuel contributions to the intersection of these two languages.
-//!
-//! ## Contributing
-//!
-//! Please read our [contributing guide](./CONTRIBUTING.md) before you start contributing.
-//!
-//! ## Architecture and Design
-//!
-//! See [architecture.md](./architecture.md).
+//!A Python package manager written in Rust. The [Cargo](https://github.com/rust-lang/cargo) for Python.
+
+//!Huak aims to be a snappy package manager for Python, supporting a standard base workflow with bootstrapping, configuration, dependency management, testing, building, and distribution tools. This package manager can be used for Python packages and projects.
+
+//!The goal is to create an opinionated tool to support an inviting onboarding experience to projects and the Python space, that's also responsive and snappy to use.
+
+//!### Milestones and Project Board
+
+//!See either **[this milestone list](https://github.com/cnpryer/huak/milestones)** or **[the issue board](https://github.com/users/cnpryer/projects/5)** to check the status of this project at any point in time.
+
+//!## README Contents
+
+//!- [Installation](#installation)
+//!- [Documentation](#documentation)
+//!- [Goals and Motivation](#goals)
+//!- [Contributing](#contributing)
+//!- [Architecture and Design](#architecture-and-design)
+
+//!## Installation
+
+//!A PoC and an 0.1.0 are expected.
+
+//!- **During the PoC phase**, clone the repository and build the release with `cargo build --release` or use `cargo install --path .` to install the CLI binary to your system.
+//!- **As 0.1.0 is finished up**, install with `cargo install huak`.
+//!- At some point you will be able to:
+//!  - `brew install huak`
+//!  - `pip install huak`
+//!  - Use GitHub release artifacts
+
+//!Distribution plans will be finalized closer to 0.1.0.
+
+//!```zsh
+//!❯ huak help
+
+//!A Python package manager written in Rust inspired by Cargo
+
+//!USAGE:
+//!    huak [SUBCOMMAND]
+
+//!OPTIONS:
+//!    -h, --help       Print help information
+//!    -V, --version    Print version information
+
+//!SUBCOMMANDS:
+//!    activate         Activate the project's virtual environment.*
+//!    add              Add a Python module to the existing project.*
+//!    build            Build tarball and wheel for the project.*
+//!    clean            Remove tarball and wheel from the built project.
+//!    clean-pycache    Remove all .pyc files and __pycache__ directories.
+//!    fmt              Format Python code.
+//!    help             Display Huak commands and general usage information.
+//!    init             Initialize the existing project.
+//!    install          Install the dependencies of an existing project.
+//!    lint             Lint Python code.
+//!    new              Create a project from scratch.
+//!    remove           Remove a dependency from the project.
+//!    run              Run a command within the project's environment context.*
+//!    test             Test Python code.
+//!    update           Update dependencies added to the project.*
+//!    version          Display the version of the project.
+
+//!    # ~ Experimental ~
+
+//!    fix              Apply auto-fixing to your Python code.**
+//!    audit            Check for just vulnerable dependencies or check
+//!                     everything including license compatibility with
+//!                     your dependencies.**
+//!    doc              Auto-generate docs for your Python project.**
+//!```
+//!_"*" indicates incomplete first-pass but planned for PoC_
+
+//!_"**" indicates incomplete first-pass but planned for 0.1.x_
+
+//!## Documentation
+
+//!Some documentation for 0.0.x releases will land on docs.rs. Around the 0.1.0 release I'd like to have more robust documentation about Huak for users, contributors, and the curious.
+
+//!## Goals
+
+//!Besides some of my own experience with the Python ecosystem, there are a few additional guiding principles steering the development of Huak:
+
+//!### 1. Open to open source 📚
+
+//!Open source has done a lot for me both from a tooling and professional development perspective. I'd love to offer Huak as a way to help onboard the absolute and relative newcomers (like myself).
+
+//!### 2. Just use `huak` ✨
+
+//!I love Rust's onboarding experience. Cargo has played a large role. It's a great tool for newcomers to use to get their feet wet. Huak can provide the same experience for Python.
+
+//!### 3. Fast ⚡️
+
+//!There's room for faster tooling in the Python ecosystem. One of the guiding principles will be "Is this the fastest it can be?"
+
+//!### 4. Python 🤝 Rust
+
+//!JavaScript has seen a "Going Rust" sub-community pop up. Python seems to be getting one too. Huak would be able to fuel contributions to the intersection of these two languages.
+
+//!## Contributing
+
+//!Please read our [contributing guide](./CONTRIBUTING.md) before you start contributing.
+
+//!## Architecture and Design
+
+//!See [architecture.md](./architecture.md).
+
 /// Configuration formats for structures and contexts.
 pub mod config;
 /// Environments for different contexts.

--- a/src/huak/utils/command.rs
+++ b/src/huak/utils/command.rs
@@ -24,7 +24,7 @@ pub(crate) fn run_command(
         ));
     }
 
-    Ok((0, msg))
+    Ok((code, msg))
 }
 
 /// Mute command utilities with HUAK_MUTE_COMMAND ("True", "true").


### PR DESCRIPTION
- Update docs.rs and small fix
- Add crates.io badge to README.md
- Start v0.0.2a
- Update the readme for doc use

PR sets up publishing an alpha for the PoC at v0.0.2a. This should only release a pre-release to crates.io.