### PR TITLE
Serialize as [[project.authors]] in pyproject.toml

### DIFF
--- a/resources/mock-project/pyproject.toml
+++ b/resources/mock-project/pyproject.toml
@@ -2,7 +2,10 @@
 name = "mock_project"
 version = "0.0.1"
 description = ""
-authors = [""]
+
+[[project.authors]]
+name = "Chris Pryer"
+email = "cnpryer@gmail.com"
 
 [project.dependencies]
 click = "8.1.3"

--- a/src/huak/config/pyproject/project/mod.rs
+++ b/src/huak/config/pyproject/project/mod.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
-use toml::{value::Map, Value};
+use toml::value::{Map, Value};
 
 /// Struct containing dependency information.
 /// ```toml
@@ -12,13 +12,24 @@ pub(crate) struct Dependency {
     pub(crate) version: String,
 }
 
+/// Struct containing Author information.
+/// ```toml
+/// [[project.authors]]
+/// name = "Chris Pryer"
+/// email = "cnpryer@gmail.com"
+/// ```
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub(crate) struct Author {
+    pub(crate) name: String,
+    pub(crate) email: String,
+}
+
 /// Project table data.
 /// ```toml
 /// [project]
 /// name = "Project"
 /// version = "0.0.1"
 /// description = ""
-/// authors = []
 /// # ...
 /// ```
 #[derive(Serialize, Deserialize)]
@@ -26,7 +37,7 @@ pub(crate) struct Project {
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) description: String,
-    pub(crate) authors: Vec<String>,
+    pub(crate) authors: Vec<Author>,
     pub(crate) dependencies: Map<String, Value>,
     #[serde(rename = "dev-dependencies")]
     pub(crate) dev_dependencies: Map<String, Value>,

--- a/src/huak/config/pyproject/toml.rs
+++ b/src/huak/config/pyproject/toml.rs
@@ -60,7 +60,10 @@ mod tests {
 name = "Test"
 version = "0.1.0"
 description = ""
-authors = []
+
+[[project.authors]]
+name = "Chris Pryer"
+email = "cnpryer@gmail.com"
 
 [project.dependencies]
 
@@ -72,7 +75,10 @@ build-backend = "huak.core.build.api"
 "#;
         let toml = Toml::from(string).unwrap();
 
-        assert_eq!(toml.to_string().unwrap(), string);
+        let res = toml.to_string().unwrap();
+        dbg!(&res);
+
+        assert_eq!(res, string);
     }
 
     #[test]
@@ -81,7 +87,10 @@ build-backend = "huak.core.build.api"
 name = "Test"
 version = "0.1.0"
 description = ""
-authors = []
+
+[[project.authors]]
+name = "Chris Pryer"
+email = "cnpryer@gmail.com"
 
 [project.dependencies]
 
@@ -94,5 +103,6 @@ build-backend = "huak.core.build.api"
         let toml = Toml::from(string).unwrap();
 
         assert_eq!(toml.project.name, "Test");
+        assert_eq!(toml.project.authors[0].name, "Chris Pryer")
     }
 }


### PR DESCRIPTION
Closes #187 

## Summary of changes

    - Deser both formats (see #187)
    - Only serialize to [[project.authors]]

See https://github.com/cnpryer/huak/issues/191 for follow ups.