### PR TITLE
Use array of strings for toml dependencies

### DIFF
--- a/resources/mock-project/pyproject.toml
+++ b/resources/mock-project/pyproject.toml
@@ -2,16 +2,11 @@
 name = "mock_project"
 version = "0.0.1"
 description = ""
+dependencies = ["click==8.1.3", "black==22.8.0"]
 
 [[project.authors]]
 name = "Chris Pryer"
 email = "cnpryer@gmail.com"
-
-[project.dependencies]
-click = "8.1.3"
-
-[project.dev-dependencies]
-black = "22.8.0"
 
 [build-system]
 requires = ["huak-core>=1.0.0"]

--- a/src/huak/config/pyproject/project/mod.rs
+++ b/src/huak/config/pyproject/project/mod.rs
@@ -1,16 +1,4 @@
 use serde_derive::{Deserialize, Serialize};
-use toml::value::{Map, Value};
-
-/// Struct containing dependency information.
-/// ```toml
-/// name = version
-/// ```
-#[allow(dead_code)]
-#[derive(Clone, Deserialize, Debug)]
-pub(crate) struct Dependency {
-    pub(crate) name: String,
-    pub(crate) version: String,
-}
 
 /// Struct containing Author information.
 /// ```toml
@@ -37,10 +25,8 @@ pub(crate) struct Project {
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) description: String,
+    pub(crate) dependencies: Vec<String>,
     pub(crate) authors: Vec<Author>,
-    pub(crate) dependencies: Map<String, Value>,
-    #[serde(rename = "dev-dependencies")]
-    pub(crate) dev_dependencies: Map<String, Value>,
 }
 
 impl Default for Project {
@@ -50,8 +36,7 @@ impl Default for Project {
             version: "0.0.1".to_string(),
             description: "".to_string(),
             authors: vec![],
-            dependencies: Map::new(),
-            dev_dependencies: Map::new(),
+            dependencies: vec![],
         }
     }
 }

--- a/src/huak/config/pyproject/toml.rs
+++ b/src/huak/config/pyproject/toml.rs
@@ -60,14 +60,11 @@ mod tests {
 name = "Test"
 version = "0.1.0"
 description = ""
+dependencies = ["click==8.1.3", "black==22.8.0"]
 
 [[project.authors]]
 name = "Chris Pryer"
 email = "cnpryer@gmail.com"
-
-[project.dependencies]
-
-[project.dev-dependencies]
 
 [build-system]
 requires = ["huak-core>=1.0.0"]
@@ -87,14 +84,11 @@ build-backend = "huak.core.build.api"
 name = "Test"
 version = "0.1.0"
 description = ""
+dependencies = ["click==8.1.3", "black==22.8.0"]
 
 [[project.authors]]
 name = "Chris Pryer"
 email = "cnpryer@gmail.com"
-
-[project.dependencies]
-
-[project.dev-dependencies]
 
 [build-system]
 requires = ["huak-core>=1.0.0"]

--- a/src/huak/env/venv.rs
+++ b/src/huak/env/venv.rs
@@ -149,11 +149,8 @@ impl PythonEnvironment for Venv {
         dependency: &PythonPackage,
     ) -> Result<(), CliError> {
         let cwd = env::current_dir()?;
-        let module_str = match dependency.version.is_empty() {
-            true => dependency.name.to_string(),
-            false => format!("{}=={}", dependency.name, dependency.version),
-        };
-        let args = ["install", &module_str];
+        let module_str = &dependency.string();
+        let args = ["install", module_str];
         let module = "pip";
 
         self.exec_module(module, &args, cwd.as_path())?;

--- a/src/huak/ops/install.rs
+++ b/src/huak/ops/install.rs
@@ -14,11 +14,7 @@ pub fn install_project_dependencies(project: &Project) -> CliResult {
         ));
     }
 
-    for dependency in &project.config().dependency_list("main") {
-        project.venv().install_package(dependency)?;
-    }
-
-    for dependency in &project.config().dependency_list("dev") {
+    for dependency in &project.config().dependency_list() {
         project.venv().install_package(dependency)?;
     }
 

--- a/src/huak/package/python.rs
+++ b/src/huak/package/python.rs
@@ -1,15 +1,21 @@
 /// A Python package struct.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct PythonPackage {
+    string: String,
     pub name: String,
     pub version: String,
 }
 
 impl PythonPackage {
-    pub fn new(name: String) -> PythonPackage {
+    pub fn new(string: String) -> PythonPackage {
         PythonPackage {
-            name,
+            string,
+            name: "".to_string(),
             version: "".to_string(),
         }
+    }
+
+    pub fn string(&self) -> &String {
+        &self.string
     }
 }

--- a/src/huak/project/config.rs
+++ b/src/huak/project/config.rs
@@ -10,7 +10,7 @@ const DEFAULT_SEARCH_STEPS: usize = 5;
 
 /// Traits for Python-specific configuration.
 pub trait PythonConfig {
-    fn dependency_list(&self, kind: &str) -> Vec<PythonPackage>;
+    fn dependency_list(&self) -> Vec<PythonPackage>;
 }
 
 /// `Manifest` data the configuration uses to manage standard configuration
@@ -97,22 +97,14 @@ impl Config {
 impl PythonConfig for Config {
     // Get vec of dependencies from the manifest.
     // TODO: More than toml.
-    fn dependency_list(&self, kind: &str) -> Vec<PythonPackage> {
+    fn dependency_list(&self) -> Vec<PythonPackage> {
         // Get huak's spanned table found in the Toml.
         let table = &self.manifest.toml.project;
 
         // Dependencies to list from.
-        let from = match kind {
-            "dev" => &table.dev_dependencies,
-            _ => &table.dependencies,
-        };
+        let from = &table.dependencies;
 
         // Collect into vector of owned `PythonPackage` data.
-        from.into_iter()
-            .map(|d| PythonPackage {
-                name: d.0.to_string(),
-                version: d.1.as_str().unwrap().to_string(),
-            })
-            .collect()
+        from.iter().map(|d| PythonPackage::new(d.clone())).collect()
     }
 }


### PR DESCRIPTION
Closes #188 

## Summary of changes

    - Change order of project table attributes.
    - `PythonPackage` is initialized with a string (TODO: name and version parsing).
    - Remove dev-dependencies from toml.
    - Change dependencies to array of strings in toml.
    - Update tests

This introduces a quirk where the dependencies in the toml must be defined before the `[[project.authors]]`. But the authors is already a quirk. So it's a 2-for-1 for now.