### PR TITLE
Fix huak new 'subproject' error

### DIFF
--- a/src/bin/huak/commands/new.rs
+++ b/src/bin/huak/commands/new.rs
@@ -42,7 +42,7 @@ pub fn run(args: &ArgMatches) -> CliResult<()> {
         fs::create_dir_all(&path)?;
     }
 
-    let project = Project::from(path)?;
+    let project = Project::new(path);
 
     ops::new::create_project(&project)?;
 

--- a/src/huak/ops/fmt.rs
+++ b/src/huak/ops/fmt.rs
@@ -7,13 +7,18 @@ const MODULE: &str = "black";
 
 /// Format Python code from the `Project`'s root.
 pub fn fmt_project(project: &Project, is_check: &bool) -> CliResult<()> {
+    let venv = match project.venv() {
+        Some(v) => v,
+        _ => return Err(CliError::new(HuakError::VenvNotFound, 1)),
+    };
+
     let res = match is_check {
-        true => project.venv().exec_module(
+        true => venv.exec_module(
             MODULE,
             &[".", "--line-length", "79", "--check"],
             &project.root,
         ),
-        false => project.venv().exec_module(
+        false => venv.exec_module(
             MODULE,
             &[".", "--line-length", "79"],
             &project.root,
@@ -51,6 +56,8 @@ mod tests {
         let project = create_mock_project(project_path.clone()).unwrap();
         project
             .venv()
+            .as_ref()
+            .unwrap()
             .exec_module("pip", &["install", MODULE], &project.root)
             .unwrap();
 

--- a/src/huak/ops/install.rs
+++ b/src/huak/ops/install.rs
@@ -1,5 +1,5 @@
 use crate::{
-    errors::{CliError, CliResult},
+    errors::{CliError, CliResult, HuakError},
     project::{config::PythonConfig, python::PythonProject, Project},
 };
 
@@ -12,8 +12,13 @@ pub fn install_project_dependencies(project: &Project) -> CliResult<()> {
         )));
     }
 
+    let venv = match project.venv() {
+        Some(v) => v,
+        _ => return Err(CliError::new(HuakError::VenvNotFound, 1)),
+    };
+
     for dependency in &project.config().dependency_list() {
-        project.venv().install_package(dependency)?;
+        venv.install_package(dependency)?;
     }
 
     Ok(())
@@ -43,7 +48,7 @@ pub mod tests {
 
         let project_path = directory.join("mock-project");
         let project = create_mock_project(project_path.clone()).unwrap();
-        let venv = project.venv();
+        let venv = project.venv().as_ref().unwrap();
 
         venv.uninstall_package("black").unwrap();
         let black_path = venv.module_path("black").unwrap();

--- a/src/huak/ops/lint.rs
+++ b/src/huak/ops/lint.rs
@@ -7,9 +7,13 @@ const MODULE: &str = "ruff";
 
 /// Lint the project from its root.
 pub fn lint_project(project: &Project) -> CliResult<()> {
-    let args = [".", "--extend-exclude", project.venv().name()?];
+    let venv = match project.venv() {
+        Some(v) => v,
+        _ => return Err(CliError::new(HuakError::VenvNotFound, 1)),
+    };
+    let args = [".", "--extend-exclude", venv.name()?];
 
-    match project.venv().exec_module(MODULE, &args, &project.root) {
+    match venv.exec_module(MODULE, &args, &project.root) {
         Err(e) => {
             let code = e.status_code;
             Err(CliError::new(HuakError::RuffError(Box::new(e)), code))

--- a/src/huak/ops/remove.rs
+++ b/src/huak/ops/remove.rs
@@ -2,6 +2,7 @@ use std::fs;
 
 use crate::{
     config::pyproject::toml::Toml,
+    errors::{CliError, HuakError},
     project::{python::PythonProject, Project},
 };
 
@@ -10,13 +11,14 @@ use crate::{
 pub fn remove_project_dependency(
     project: &Project,
     dependency: &str,
-) -> Result<(), anyhow::Error> {
-    let venv = project.venv();
+) -> Result<(), CliError> {
+    let venv = match project.venv() {
+        Some(v) => v,
+        _ => return Err(CliError::new(HuakError::VenvNotFound, 1)),
+    };
 
     // TODO: #109
-    if let Err(e) = venv.uninstall_package(dependency) {
-        return Err(anyhow::format_err!(e));
-    };
+    venv.uninstall_package(dependency)?;
 
     let mut toml = Toml::open(&project.root.join("pyproject.toml"))?;
     toml.project
@@ -24,7 +26,11 @@ pub fn remove_project_dependency(
         .retain(|s| !s.starts_with(dependency));
 
     // Serialize pyproject.toml.
-    fs::write(&project.root.join("pyproject.toml"), toml.to_string()?)?;
+    let string = match toml.to_string() {
+        Ok(s) => s,
+        Err(_) => return Err(CliError::new(HuakError::IOError, 1)),
+    };
+    fs::write(&project.root.join("pyproject.toml"), string)?;
 
     Ok(())
 }

--- a/src/huak/ops/test.rs
+++ b/src/huak/ops/test.rs
@@ -8,7 +8,10 @@ const MODULE: &str = "pytest";
 /// Test a project using `pytest`.
 pub fn test_project(project: &Project) -> CliResult<()> {
     let args = [];
-    let venv = project.venv();
+    let venv = match project.venv() {
+        Some(v) => v,
+        _ => return Err(CliError::new(HuakError::VenvNotFound, 1)),
+    };
 
     match venv.exec_module(MODULE, &args, &project.root) {
         Ok(_) => Ok(()),

--- a/src/huak/project/mod.rs
+++ b/src/huak/project/mod.rs
@@ -11,10 +11,20 @@ use self::python::PythonProject;
 pub struct Project {
     pub root: PathBuf,
     config: Config,
-    venv: Venv,
+    venv: Option<Venv>,
 }
 
 impl Project {
+    /// Initialize `Project` at a given path. This creates a `Project` without
+    /// attempting to construct it through project artifact searches.
+    pub fn new(path: PathBuf) -> Project {
+        Project {
+            root: path,
+            config: Config::default(),
+            venv: None,
+        }
+    }
+
     /// Initialize `Project` from a given path. If a manifest isn't found
     /// at the path, then we search for a manifest and set the project root
     /// if it's found.
@@ -39,7 +49,11 @@ impl Project {
             root = parent.to_path_buf()
         }
 
-        Ok(Project { root, config, venv })
+        Ok(Project {
+            root,
+            config,
+            venv: Some(venv),
+        })
     }
 }
 
@@ -51,14 +65,14 @@ impl PythonProject for Project {
 
     /// Get a reference to the `Project` `Venv`.
     // TODO: Decouple to operate on `Config` data.
-    fn venv(&self) -> &Venv {
+    fn venv(&self) -> &Option<Venv> {
         &self.venv
     }
 
     /// Set the `Project`'s `Venv`.
     // TODO: Decouple to operate on `Config` data.
     fn set_venv(&mut self, venv: Venv) {
-        self.venv = venv;
+        self.venv = Some(venv);
     }
 }
 
@@ -91,6 +105,9 @@ mod tests {
         .unwrap();
 
         assert_eq!(project1.root, project2.root);
-        assert_eq!(project1.venv().path, project2.venv().path);
+        assert_eq!(
+            project1.venv().as_ref().unwrap().path,
+            project2.venv().as_ref().unwrap().path
+        );
     }
 }

--- a/src/huak/project/python.rs
+++ b/src/huak/project/python.rs
@@ -4,6 +4,6 @@ use crate::env::venv::Venv;
 /// Traits for a `PythonProject`.
 pub trait PythonProject {
     fn config(&self) -> &Config;
-    fn venv(&self) -> &Venv;
+    fn venv(&self) -> &Option<Venv>;
     fn set_venv(&mut self, venv: Venv);
 }


### PR DESCRIPTION
This adds Project::new to initialize a blank project to bootstrap from. Originally new was attempting a manifest search and failing to create the subproject.

This is a WIP but allows `huak new 'project'` from within an already created project.

In order to do this I've made Project.venv an `Option`.