### PR TITLE
Add optional-dependencies

### DIFF
--- a/resources/mock-project/pyproject.toml
+++ b/resources/mock-project/pyproject.toml
@@ -2,7 +2,8 @@
 name = "mock_project"
 version = "0.0.1"
 description = ""
-dependencies = ["click==8.1.3", "black==22.8.0"]
+dependencies = ["click==8.1.3"]
+optional-dependencies = ["black==22.8.0"]
 
 [[project.authors]]
 name = "Chris Pryer"

--- a/src/bin/huak/commands/version.rs
+++ b/src/bin/huak/commands/version.rs
@@ -4,7 +4,7 @@ use clap::Command;
 use huak::{
     errors::{CliError, CliResult},
     ops,
-    project::{python::PythonProject, Project},
+    project::Project,
 };
 
 use super::utils::subcommand;

--- a/src/huak/config/pyproject/mod.rs
+++ b/src/huak/config/pyproject/mod.rs
@@ -1,6 +1,3 @@
-/// Build system toml configuration.
 pub(crate) mod build_system;
-/// Project toml configuration.
 pub(crate) mod project;
-/// Toml configuration.
 pub(crate) mod toml;

--- a/src/huak/config/pyproject/project/mod.rs
+++ b/src/huak/config/pyproject/project/mod.rs
@@ -26,6 +26,8 @@ pub(crate) struct Project {
     pub(crate) version: String,
     pub(crate) description: String,
     pub(crate) dependencies: Vec<String>,
+    #[serde(rename = "optional-dependencies")]
+    pub(crate) optional_dependencies: Option<Vec<String>>,
     pub(crate) authors: Vec<Author>,
 }
 
@@ -37,6 +39,7 @@ impl Default for Project {
             description: "".to_string(),
             authors: vec![],
             dependencies: vec![],
+            optional_dependencies: Some(vec![]),
         }
     }
 }

--- a/src/huak/ops/fmt.rs
+++ b/src/huak/ops/fmt.rs
@@ -1,7 +1,4 @@
-use crate::{
-    errors::HuakError,
-    project::{python::PythonProject, Project},
-};
+use crate::{errors::HuakError, project::Project};
 
 const MODULE: &str = "black";
 

--- a/src/huak/ops/lint.rs
+++ b/src/huak/ops/lint.rs
@@ -1,7 +1,4 @@
-use crate::{
-    errors::HuakError,
-    project::{python::PythonProject, Project},
-};
+use crate::{errors::HuakError, project::Project};
 
 const MODULE: &str = "ruff";
 

--- a/src/huak/ops/remove.rs
+++ b/src/huak/ops/remove.rs
@@ -62,24 +62,39 @@ mod tests {
             create_mock_project(directory.join("mock-project")).unwrap();
         let toml_path = project.root.join("pyproject.toml");
         let toml = Toml::open(&toml_path).unwrap();
-        let prev = toml
+        let existed = toml
             .project
             .dependencies
-            .into_iter()
-            .filter(|s| s.starts_with("click"))
-            .collect::<Vec<String>>();
+            .iter()
+            .any(|d| d.starts_with("click"));
+        let existed = existed
+            && toml
+                .project
+                .optional_dependencies
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|d| d.starts_with("black"));
 
         remove_project_dependency(&project, "click").unwrap();
 
         let toml = Toml::open(&toml_path).unwrap();
-        let curr = toml
+        let exists = !toml
             .project
             .dependencies
-            .into_iter()
-            .filter(|s| s.starts_with("click"))
-            .collect::<Vec<String>>();
+            .iter()
+            .any(|s| s.starts_with("black"));
 
-        assert!(!prev.is_empty());
-        assert!(curr.is_empty());
+        let exists = exists
+            && toml
+                .project
+                .optional_dependencies
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|s| s.starts_with("black"));
+
+        assert!(existed);
+        assert!(exists);
     }
 }

--- a/src/huak/ops/remove.rs
+++ b/src/huak/ops/remove.rs
@@ -1,9 +1,7 @@
 use std::fs;
 
 use crate::{
-    config::pyproject::toml::Toml,
-    errors::HuakError,
-    project::{python::PythonProject, Project},
+    config::pyproject::toml::Toml, errors::HuakError, project::Project,
 };
 
 /// Remove a dependency from a project by uninstalling it and updating the

--- a/src/huak/ops/test.rs
+++ b/src/huak/ops/test.rs
@@ -1,7 +1,4 @@
-use crate::{
-    errors::HuakError,
-    project::{python::PythonProject, Project},
-};
+use crate::{errors::HuakError, project::Project};
 
 const MODULE: &str = "pytest";
 

--- a/src/huak/ops/version.rs
+++ b/src/huak/ops/version.rs
@@ -1,7 +1,4 @@
-use crate::{
-    errors::HuakError,
-    project::{python::PythonProject, Project},
-};
+use crate::{errors::HuakError, project::Project};
 
 /// Get the version of a project.
 pub fn get_project_version(project: &Project) -> Result<&str, HuakError> {

--- a/src/huak/project/mod.rs
+++ b/src/huak/project/mod.rs
@@ -1,12 +1,10 @@
 pub mod config;
-pub mod python;
 use std::path::PathBuf;
 
 use crate::env::venv::{self, Venv};
 use crate::errors::HuakError;
 
 use self::config::Config;
-use self::python::PythonProject;
 
 /// The ``Project`` struct.
 /// The ``Project`` struct provides and API for maintaining project. The pattern for
@@ -83,21 +81,21 @@ impl Project {
     }
 }
 
-impl PythonProject for Project {
+impl Project {
     /// Get a reference to the `Project` `Config`.
-    fn config(&self) -> &Config {
+    pub fn config(&self) -> &Config {
         &self.config
     }
 
     /// Get a reference to the `Project` `Venv`.
     // TODO: Decouple to operate on `Config` data.
-    fn venv(&self) -> &Option<Venv> {
+    pub fn venv(&self) -> &Option<Venv> {
         &self.venv
     }
 
     /// Set the `Project`'s `Venv`.
     // TODO: Decouple to operate on `Config` data.
-    fn set_venv(&mut self, venv: Venv) {
+    pub fn set_venv(&mut self, venv: Venv) {
         self.venv = Some(venv);
     }
 }

--- a/src/huak/project/python.rs
+++ b/src/huak/project/python.rs
@@ -1,9 +1,0 @@
-use super::config::Config;
-use crate::env::venv::Venv;
-
-/// Traits for a `PythonProject`.
-pub trait PythonProject {
-    fn config(&self) -> &Config;
-    fn venv(&self) -> &Option<Venv>;
-    fn set_venv(&mut self, venv: Venv);
-}

--- a/src/huak/utils/test_utils.rs
+++ b/src/huak/utils/test_utils.rs
@@ -1,10 +1,6 @@
 use std::{env, path::PathBuf};
 
-use crate::{
-    env::venv::Venv,
-    errors::HuakError,
-    project::{python::PythonProject, Project},
-};
+use crate::{env::venv::Venv, errors::HuakError, project::Project};
 
 pub fn get_resource_dir() -> PathBuf {
     let cwd = env!("CARGO_MANIFEST_DIR");


### PR DESCRIPTION
Closes #197 

## Summary of changes

    - Chore: Remove use of PythonProject trait (simplify while use cases are discovered)
    - Config.dependency_list -> .package_list (was confusing since returned vec of PythonPackage)
    - Add Config.optional_package_list
    - Add test coverge in ops::remove

Some notes:

    - would have liked to initialize arbitrary `Project` from a toml string. then set. #232 
    - would like to split optional and main removal tests
