### PR TITLE
PythonPackage parse from string++

### DIFF
--- a/src/huak/lib.rs
+++ b/src/huak/lib.rs
@@ -119,6 +119,8 @@
 //!     └── utils     # Library utilities
 //! ```
 
+extern crate core;
+
 /// Configuration formats for structures and contexts.
 pub mod config;
 /// Environments for different contexts.

--- a/src/huak/ops/install.rs
+++ b/src/huak/ops/install.rs
@@ -58,7 +58,7 @@ pub mod tests {
 
     // TODO
     #[test]
-    fn installs_dependenices() {
+    fn installs_dependencies() {
         let directory = tempdir().unwrap().into_path().to_path_buf();
         let mock_project_dir = get_resource_dir().join("mock-project");
         copy_dir(&mock_project_dir, &directory);

--- a/src/huak/package/python.rs
+++ b/src/huak/package/python.rs
@@ -1,6 +1,9 @@
+use core::fmt;
+
 const DEFAULT_VERSION_OP: &str = "==";
 
-/// A Python package struct.
+/// A Python package struct that captures a packages name and version
+/// see https://peps.python.org/pep-0440/
 // At the moment (during the PoC phase) the `PythonPackage` contains a
 // private string attribute for Huak to utilize.
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -10,6 +13,7 @@ pub struct PythonPackage {
     pub op: Option<String>, // Enum?
     pub version: Option<String>,
 }
+
 
 impl PythonPackage {
     pub fn new(
@@ -40,6 +44,26 @@ impl PythonPackage {
         &self.string
     }
 }
+
+impl fmt::Display for PythonPackage{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // check if a version is specified
+        if let Some(ver) = &self.version {
+            // check if a version specifier (operator) is supplied
+            if let Some(operator) = &self.op {
+                write!(f, "{}{}{}", self.name, operator, ver)
+            } else {
+                // if no version specifier, default to '=='
+                write!(f, "{}=={}", self.name, ver)
+            }
+        } else {
+            // if no version, just display python package name
+            write!(f, "{}", self.name )
+        }
+    }
+
+}
+
 
 fn _package_from_string(
     _string: String,
@@ -85,5 +109,14 @@ mod tests {
 
         assert_eq!(res1, ans1);
         assert_eq!(res2, ans2);
+    }
+
+    #[test]
+    fn python_package_from_new() {
+        let pkg_name = "test";
+        let pkg_version: Option<&str> = Some("0.0.1");
+        let python_pkg = PythonPackage::new(pkg_name, None, pkg_version);
+        let test_output = format!("{}", python_pkg);
+        assert_eq!(test_output, "test==0.0.1");
     }
 }

--- a/src/huak/package/python.rs
+++ b/src/huak/package/python.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::str::FromStr;
 
 const DEFAULT_VERSION_OP: &str = "==";
 
@@ -6,25 +7,26 @@ const DEFAULT_VERSION_OP: &str = "==";
 /// see https://peps.python.org/pep-0440/
 // At the moment (during the PoC phase) the `PythonPackage` contains a
 // private string attribute for Huak to utilize.
-#[derive(Clone, Eq, PartialEq, Debug)]
+// #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct PythonPackage {
-    string: String, // TODO: More like a view maybe.
+    // string: String, // TODO: More like a view maybe.
     pub name: String,
-    pub op: Option<String>,
+    pub op: Option<VersionSpecifier>,
     pub version: Option<String>,
 }
 
 /// Python Package version specifiers per PEP-0440
 /// https://peps.python.org/pep-0440/#version-specifiers
+#[derive(PartialEq, Debug)]
 pub enum VersionSpecifier {
-    Compatible,
-    Matching,
-    Exclusion,
-    GreaterIncluding,
-    LesserIncluding,
-    GreaterExcluding,
-    LesserExcluding,
-    ArbitraryEqual,
+    Compatible,         // ~=
+    Matching,           // == currently the default
+    Exclusion,          // !=
+    GreaterIncluding,   // >=
+    LesserIncluding,    // <=
+    GreaterExcluding,   // <
+    LesserExcluding,    // >
+    ArbitraryEqual,     // ===
 }
 
 
@@ -34,31 +36,56 @@ impl PythonPackage {
         op: Option<&str>,
         version: Option<&str>,
     ) -> PythonPackage {
-        let string = package_string_from_parts(name, &op, &version);
-
-        PythonPackage {
-            string,
-            name: name.to_string(),
-            op: op.map(|it| it.to_string()),
-            version: version.map(|it| it.to_string()),
+        if let Some(operator) = op {
+            let op_from_string = VersionSpecifier::from_str(operator).unwrap();
+            PythonPackage {
+                name: name.to_string(),
+                op: Some(op_from_string),
+                version: version.map(|it| it.to_string()),
+            }
+        } else {
+            PythonPackage {
+                name: name.to_string(),
+                op: Some(VersionSpecifier::default()),
+                version: version.map(|it| it.to_string()),
+            }
         }
     }
 
-    pub fn from(string: String) -> PythonPackage {
-        PythonPackage {
-            string,
-            name: "".to_string(), // TODO
-            op: None,
-            version: None,
+    pub fn from(pkg_string: String) -> PythonPackage {
+        let version_operators = ["==", "~=", "!=", ">=", "<=", ">", "<", "==="].into_iter();
+        let mut op = "==";
+        let mut op2: Option<&str> = None;
+        for i in version_operators {
+            if pkg_string.contains(i) {
+                op2 = Some(i);
+                op = i;
+                break;
+            }
+        }
+        return if pkg_string.contains(op) {
+            let pkg_components = pkg_string.split(op);
+            let pkg_vec = pkg_components.collect::<Vec<&str>>();
+            PythonPackage {
+                name: pkg_vec[0].to_string(),
+                op: Some(VersionSpecifier::from_str(op).unwrap()),
+                version: Some(pkg_vec[1].to_string()),
+            }
+        } else {
+            PythonPackage {
+                name: pkg_string,
+                op: None,
+                version: None,
+            }
         }
     }
 
     pub fn string(&self) -> &String {
-        &self.string
+        &self.name
     }
 }
 
-/// display a PythonPackage as the name and version when available
+/// Display a PythonPackage as the name and version when available
 impl fmt::Display for PythonPackage{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // check if a version is specified
@@ -77,6 +104,7 @@ impl fmt::Display for PythonPackage{
     }
 }
 
+/// Display VersionSpecifier enum (e.g., via "{}")
 impl fmt::Display for VersionSpecifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let operator = {
@@ -92,6 +120,32 @@ impl fmt::Display for VersionSpecifier {
             }
         };
         write!(f, "{}", operator)
+    }
+}
+
+/// Convert a string to our VersionSpecifier enum
+/// can be used like VersionSpecifier::from_str("==").unwrap())
+impl FromStr for VersionSpecifier {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "~=" => Ok(VersionSpecifier::Compatible),
+            "==" => Ok(VersionSpecifier::Matching),
+            "!=" => Ok(VersionSpecifier::Exclusion),
+            "===" => Ok(VersionSpecifier::ArbitraryEqual),
+            "<=" => Ok(VersionSpecifier::LesserIncluding),
+            "<" => Ok(VersionSpecifier::LesserExcluding),
+            ">=" => Ok(VersionSpecifier::GreaterIncluding),
+            ">" => Ok(VersionSpecifier::GreaterExcluding),
+            _ => Err(())
+        }
+    }
+}
+
+/// The default option for VersionSpecifier enum
+impl Default for VersionSpecifier {
+    fn default() -> Self {
+        VersionSpecifier::Matching
     }
 }
 
@@ -133,11 +187,9 @@ mod tests {
             ("test", "==", "0.0.0", "test==0.0.0");
         let (name2, version2, ans2) = ("test", "0.0.0", "test==0.0.0");
         let op2: Option<&str> = None;
-
         let res1 =
             package_string_from_parts(name1, &Some(op1), &Some(version1));
         let res2 = package_string_from_parts(name2, &op2, &Some(version2));
-
         assert_eq!(res1, ans1);
         assert_eq!(res2, ans2);
     }
@@ -157,5 +209,32 @@ mod tests {
         assert_eq!("~=", test_formatted_output);
     }
 
+    #[test]
+    fn create_python_package_struct_from_string() {
+        let dependency = "test".to_string();
+        let version: String = "0.1.0".to_string();
+        let operator: String = "==".to_string();
+        let  new_pkg_from_string= PythonPackage::from(format!("{}{}{}", dependency, operator, version));
+        assert_eq!(new_pkg_from_string.name, dependency);
+        if let Some(op_from_new_pkg) = new_pkg_from_string.op{
+            let op_from_new_pkg= format!("{}", op_from_new_pkg);
+            assert_eq!(op_from_new_pkg, operator);
+        }
+        assert_eq!(new_pkg_from_string.version.unwrap(), version);
+        let operator: String = "!=".to_string();
+        let second_pkg_from_string= PythonPackage::from(format!("{}{}{}", dependency, operator, version));
+        assert!(second_pkg_from_string.op.is_some());
+        if let Some(op_from_second) = second_pkg_from_string.op{
+            let op_from_second= format!("{}", op_from_second);
+            assert_eq!(op_from_second, operator);
+        }
+    }
+
+    #[test]
+    fn enum_version_operator_from_string() {
+        // ToDo: test that the implementation of FromStr for VersionSpecifier either
+        //  1. returns an enum when one of the PEP defined string is passed
+        //  2. returns a error (something that can, eventually, be passed to the CLI)
+    }
 
 }

--- a/src/huak/package/python.rs
+++ b/src/huak/package/python.rs
@@ -10,8 +10,21 @@ const DEFAULT_VERSION_OP: &str = "==";
 pub struct PythonPackage {
     string: String, // TODO: More like a view maybe.
     pub name: String,
-    pub op: Option<String>, // Enum?
+    pub op: Option<String>,
     pub version: Option<String>,
+}
+
+/// Python Package version specifiers per PEP-0440
+/// https://peps.python.org/pep-0440/#version-specifiers
+pub enum VersionSpecifier {
+    Compatible,
+    Matching,
+    Exclusion,
+    GreaterIncluding,
+    LesserIncluding,
+    GreaterExcluding,
+    LesserExcluding,
+    ArbitraryEqual,
 }
 
 
@@ -45,6 +58,7 @@ impl PythonPackage {
     }
 }
 
+/// display a PythonPackage as the name and version when available
 impl fmt::Display for PythonPackage{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // check if a version is specified
@@ -61,7 +75,24 @@ impl fmt::Display for PythonPackage{
             write!(f, "{}", self.name )
         }
     }
+}
 
+impl fmt::Display for VersionSpecifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let operator = {
+            match self {
+                VersionSpecifier::Compatible => "~=",
+                VersionSpecifier::Matching => "==",
+                VersionSpecifier::Exclusion => "!=",
+                VersionSpecifier::ArbitraryEqual => "===",
+                VersionSpecifier::LesserIncluding=> "<=",
+                VersionSpecifier::LesserExcluding => "<",
+                VersionSpecifier::GreaterIncluding => ">=",
+                VersionSpecifier::GreaterExcluding => ">",
+            }
+        };
+        write!(f, "{}", operator)
+    }
 }
 
 
@@ -112,11 +143,19 @@ mod tests {
     }
 
     #[test]
-    fn python_package_from_new() {
+    fn display_python_package() {
         let pkg_name = "test";
         let pkg_version: Option<&str> = Some("0.0.1");
         let python_pkg = PythonPackage::new(pkg_name, None, pkg_version);
-        let test_output = format!("{}", python_pkg);
-        assert_eq!(test_output, "test==0.0.1");
+        let py_pkg_fmt = format!("{}", python_pkg);
+        assert_eq!(py_pkg_fmt, "test==0.0.1");
     }
+
+    #[test]
+    fn display_version_operator() {
+        let test_formatted_output = format!("{}", VersionSpecifier::Compatible);
+        assert_eq!("~=", test_formatted_output);
+    }
+
+
 }


### PR DESCRIPTION
howdy, 

closes #199

The scope of this pull request got a little bigger than I intended it to, and the PythonPackage was pretty much completely re-implemented. While all test are passing on my end, if this causes problems or just simply isn't what you envisioned, don't feel bad about saying so. 

here's what we got in this puppy...

1. implement PythonPackage.op as a new enum (VersionOp)
2. PythonPackage private "string" field is replaced by all aspects of the struct field (the string field is gone)
3. New enum VersionOp
4. The following trait implementation
    - VersionOp
        - Default
        - std::str::FromStr
        - core::fmt::Display
    - PythonPackage
        - core::fmt::Display
        - re-implement ::from method so let foo = PythonPackage::from("requests==2.28.1".to_string()); parses the python package/dependency from the string.
5. Documentation for many pub structs and functions
6. new test and some todo/placeholder tests 

just realize I didn't re-implement PythonPackage's string function, it returns the name currently. we can fix that though.

Like i said, it's a lot so if you have questions or just outright is not what you're looking for, just let me know.

I wouldn't consider myself a "rustacean" so there may also be plenty of way to improve/make more idiomatic. 