### PR TITLE
Use HuakError in PythonPackage init

### DIFF
--- a/src/huak/errors.rs
+++ b/src/huak/errors.rs
@@ -30,7 +30,7 @@ pub enum HuakError {
     VenvNotFound,
     PyProjectTomlNotFound, // TODO: Manfiest
     PackageInstallFailure(String),
-    InvalidPyPackageVersion(String),
+    InvalidPyPackageVersionOp(String),
 }
 
 #[derive(Debug)]
@@ -100,8 +100,9 @@ impl fmt::Display for CliError {
                 binding = format!("Failed to install package: {package}.");
                 binding.as_str()
             }
-            HuakError::InvalidPyPackageVersion(version) => {
-                binding = format!("Invalid Python package version: {version}.");
+            HuakError::InvalidPyPackageVersionOp(op) => {
+                binding =
+                    format!("Invalid Python package version operator: {op}.");
                 binding.as_str()
             }
         };

--- a/src/huak/errors.rs
+++ b/src/huak/errors.rs
@@ -30,6 +30,7 @@ pub enum HuakError {
     VenvNotFound,
     PyProjectTomlNotFound, // TODO: Manfiest
     PackageInstallFailure(String),
+    InvalidPyPackageVersion(String),
 }
 
 #[derive(Debug)]
@@ -97,6 +98,10 @@ impl fmt::Display for CliError {
             }
             HuakError::PackageInstallFailure(package) => {
                 binding = format!("Failed to install package: {package}.");
+                binding.as_str()
+            }
+            HuakError::InvalidPyPackageVersion(version) => {
+                binding = format!("Invalid Python package version: {version}.");
                 binding.as_str()
             }
         };

--- a/src/huak/errors.rs
+++ b/src/huak/errors.rs
@@ -29,7 +29,8 @@ pub enum HuakError {
     PythonNotFound,
     VenvNotFound,
     PyProjectTomlNotFound, // TODO: Manfiest
-    PackageInstallFailure(String),
+    PyPackageInstallFailure(String),
+    PyPackageInitError(String),
     InvalidPyPackageVersionOp(String),
 }
 
@@ -96,8 +97,13 @@ impl fmt::Display for CliError {
             HuakError::PyProjectTomlNotFound => {
                 "A pyproject.toml could not be found."
             }
-            HuakError::PackageInstallFailure(package) => {
-                binding = format!("Failed to install package: {package}.");
+            HuakError::PyPackageInstallFailure(package) => {
+                binding =
+                    format!("Failed to install Python package: {package}.");
+                binding.as_str()
+            }
+            HuakError::PyPackageInitError(package) => {
+                binding = format!("Failed to init Python package: {package}.");
                 binding.as_str()
             }
             HuakError::InvalidPyPackageVersionOp(op) => {

--- a/src/huak/ops/add.rs
+++ b/src/huak/ops/add.rs
@@ -52,7 +52,7 @@ pub fn add_project_dependency(
     let dep = package.string();
 
     if venv.install_package(&package).is_err() {
-        return Err(HuakError::PackageInstallFailure(dep.clone()));
+        return Err(HuakError::PyPackageInstallFailure(dep.clone()));
     };
 
     match is_dev {

--- a/src/huak/ops/add.rs
+++ b/src/huak/ops/add.rs
@@ -42,7 +42,7 @@ pub fn add_project_dependency(
     let version = json.info.version;
     let name = json.info.name;
     let package =
-        PythonPackage::new(name.as_str(), None, Some(version.as_str()));
+        PythonPackage::new(name.as_str(), None, Some(version.as_str()))?;
 
     let venv = match project.venv() {
         Some(v) => v,

--- a/src/huak/package/python.rs
+++ b/src/huak/package/python.rs
@@ -61,7 +61,7 @@ impl PythonPackage {
                 let op_string = match VersionOp::from_str(it) {
                     Ok(res) => res,
                     Err(_) => {
-                        return Err(HuakError::InvalidPyPackageVersion(
+                        return Err(HuakError::InvalidPyPackageVersionOp(
                             it.to_string(),
                         ))
                     }

--- a/src/huak/package/python.rs
+++ b/src/huak/package/python.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use std::str::FromStr;
 
+use crate::errors::HuakError;
+
 /// Version operators used in dependency strings.
 const VERSION_OPERATORS: [&str; 8] =
     ["==", "~=", "!=", ">=", "<=", ">", "<", "==="];
@@ -19,8 +21,8 @@ const VERSION_OPERATORS: [&str; 8] =
 pub struct PythonPackage {
     /// The name of the python package, pretty straight forward, why are you reading this?
     pub name: String,
-    /// op represents PEP's Version Specifiers, such as "==" or "<="
-    pub op: Option<VersionOp>,
+    /// Th operator represents PEP's Version Specifiers, such as "==" or "<="
+    pub operator: Option<VersionOp>,
     /// The semantic version associated with a python package
     pub version: Option<String>,
 }
@@ -51,23 +53,38 @@ pub enum VersionOp {
 impl PythonPackage {
     pub fn new(
         name: &str,
-        op: Option<&str>,
+        operator: Option<&str>,
         version: Option<&str>,
-    ) -> PythonPackage {
-        if let Some(operator) = op {
-            let op_from_string = VersionOp::from_str(operator).unwrap();
-            PythonPackage {
-                name: name.to_string(),
-                op: Some(op_from_string),
-                version: version.map(|it| it.to_string()),
+    ) -> Result<PythonPackage, HuakError> {
+        let op = match operator {
+            Some(it) => {
+                let op_string = match VersionOp::from_str(it) {
+                    Ok(res) => res,
+                    Err(_) => {
+                        return Err(HuakError::InvalidPyPackageVersion(
+                            it.to_string(),
+                        ))
+                    }
+                };
+
+                Some(op_string)
             }
-        } else {
-            PythonPackage {
-                name: name.to_string(),
-                op: Some(VersionOp::default()),
-                version: version.map(|it| it.to_string()),
+            None => {
+                if version.is_none() {
+                    None
+                } else {
+                    Some(VersionOp::default())
+                }
             }
-        }
+        };
+
+        let ver = version.map(|it| it.to_string());
+
+        Ok(PythonPackage {
+            name: name.to_string(),
+            operator: op,
+            version: ver,
+        })
     }
 
     /// Instantiate a PythonPackage struct from a String
@@ -85,6 +102,7 @@ impl PythonPackage {
         // to derive an iterable from out VersionOp enum
         let version_operators = VERSION_OPERATORS.into_iter();
         let mut op: Option<&str> = None;
+        // TODO: Collect from filter on iter. Maybe contains.
         for i in version_operators {
             if pkg_string.contains(i) {
                 op = Some(i);
@@ -97,13 +115,13 @@ impl PythonPackage {
                 let pkg_vec = pkg_components.collect::<Vec<&str>>();
                 PythonPackage {
                     name: pkg_vec[0].to_string(),
-                    op: Some(VersionOp::from_str(it).unwrap()),
+                    operator: Some(VersionOp::from_str(it).unwrap()),
                     version: Some(pkg_vec[1].to_string()),
                 }
             }
             None => PythonPackage {
                 name: pkg_string,
-                op: None,
+                operator: None,
                 version: None,
             },
         };
@@ -129,7 +147,7 @@ impl fmt::Display for PythonPackage {
         // check if a version is specified
         if let Some(ver) = &self.version {
             // check if a version specifier (operator) is supplied
-            if let Some(operator) = &self.op {
+            if let Some(operator) = &self.operator {
                 write!(f, "{}{}{}", self.name, operator, ver)
             } else {
                 // if no version specifier, default to '=='
@@ -211,7 +229,8 @@ mod tests {
     fn display_python_package() {
         let pkg_name = "test";
         let pkg_version: Option<&str> = Some("0.0.1");
-        let python_pkg = PythonPackage::new(pkg_name, None, pkg_version);
+        let python_pkg =
+            PythonPackage::new(pkg_name, None, pkg_version).unwrap();
         let py_pkg_fmt = format!("{}", python_pkg);
         assert_eq!(py_pkg_fmt, "test==0.0.1");
     }
@@ -233,7 +252,7 @@ mod tests {
             dependency, operator, version
         ));
         assert_eq!(new_pkg_from_string.name, dependency);
-        if let Some(op_from_new_pkg) = new_pkg_from_string.op {
+        if let Some(op_from_new_pkg) = new_pkg_from_string.operator {
             assert_eq!(format!("{}", op_from_new_pkg), operator);
         }
         assert_eq!(new_pkg_from_string.version.unwrap(), version);

--- a/src/huak/project/config.rs
+++ b/src/huak/project/config.rs
@@ -109,7 +109,7 @@ impl PythonConfig for Config {
 
         // Collect into vector of owned `PythonPackage` data.
         from.iter()
-            .map(|d| PythonPackage::from(d.clone()))
+            .filter_map(|d| PythonPackage::from(d.clone()).ok())
             .collect()
     }
     // Get vec of `PythonPackage`s from the manifest.
@@ -126,7 +126,7 @@ impl PythonConfig for Config {
 
         // Collect into vector of owned `PythonPackage` data.
         from.iter()
-            .map(|d| PythonPackage::from(d.clone()))
+            .filter_map(|d| PythonPackage::from(d.clone()).ok())
             .collect()
     }
 }


### PR DESCRIPTION
adds InvalidPyPackageVersionOp, PyPackageInitError. Renames PackageInstallFailure to PyPackageInstallFailure.

limited amount of error changes to leave to #216.
