### PR TITLE
Restructure optional dependencies

### DIFF
--- a/resources/mock-project/pyproject.toml
+++ b/resources/mock-project/pyproject.toml
@@ -2,8 +2,10 @@
 name = "mock_project"
 version = "0.0.1"
 description = ""
-dependencies = ["click==8.1.3"]
-optional-dependencies = ["black==22.8.0"]
+dependencies = ["click==8.1.3", "black==22.8.0"]
+
+[project.optional-dependencies]
+test = ["pytest>=6", "mock"]
 
 [[project.authors]]
 name = "Chris Pryer"

--- a/src/bin/huak/commands/install.rs
+++ b/src/bin/huak/commands/install.rs
@@ -13,7 +13,7 @@ pub fn run() -> CliResult<()> {
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
 
-    if let Err(e) = ops::install::install_project_dependencies(&project) {
+    if let Err(e) = ops::install::install_project_dependencies(&project, &[]) {
         return Err(CliError::new(e, ExitCode::FAILURE));
     };
 

--- a/src/huak/config/pyproject/project/mod.rs
+++ b/src/huak/config/pyproject/project/mod.rs
@@ -1,4 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Struct containing Author information.
 /// ```toml
@@ -27,7 +28,7 @@ pub(crate) struct Project {
     pub(crate) description: String,
     pub(crate) dependencies: Vec<String>,
     #[serde(rename = "optional-dependencies")]
-    pub(crate) optional_dependencies: Option<Vec<String>>,
+    pub(crate) optional_dependencies: Option<HashMap<String, Vec<String>>>,
     pub(crate) authors: Vec<Author>,
 }
 
@@ -39,7 +40,7 @@ impl Default for Project {
             description: "".to_string(),
             authors: vec![],
             dependencies: vec![],
-            optional_dependencies: Some(vec![]),
+            optional_dependencies: None,
         }
     }
 }

--- a/src/huak/env/venv.rs
+++ b/src/huak/env/venv.rs
@@ -180,7 +180,7 @@ impl Venv {
         Ok(())
     }
 
-    /// Install a dependency from the venv.
+    /// Uninstall a dependency from the venv.
     pub fn uninstall_package(&self, name: &str) -> Result<(), CliError> {
         let cwd = env::current_dir()?;
         let module = "pip";

--- a/src/huak/ops/add.rs
+++ b/src/huak/ops/add.rs
@@ -56,7 +56,7 @@ pub fn add_project_dependency(
     };
 
     match is_dev {
-        true => toml.add_optional_dependency(dep),
+        true => toml.add_optional_dependency("dev", dep),
         false => toml.add_dependency(dep),
     }
 

--- a/src/huak/ops/install.rs
+++ b/src/huak/ops/install.rs
@@ -8,6 +8,7 @@ use crate::{
 /// Install all of the projects defined dependencies.
 pub fn install_project_dependencies(
     project: &Project,
+    optional_groups: &[&str],
 ) -> Result<(), HuakError> {
     // TODO: Doing this venv handling seems hacky.
     if !project.root.join("pyproject.toml").exists() {
@@ -20,7 +21,9 @@ pub fn install_project_dependencies(
     };
 
     install_packages(&project.config().package_list(), venv)?;
-    install_packages(&project.config().optional_package_list(), venv)?;
+    for group in optional_groups {
+        install_packages(&project.config().optional_package_list(group), venv)?;
+    }
 
     Ok(())
 }
@@ -71,7 +74,7 @@ pub mod tests {
         let black_path = venv.module_path("black").unwrap();
         let had_black = black_path.exists();
 
-        install_project_dependencies(&project).unwrap();
+        install_project_dependencies(&project, &["test"]).unwrap();
 
         assert!(!had_black);
         assert!(venv.module_path("black").unwrap().exists());

--- a/src/huak/ops/remove.rs
+++ b/src/huak/ops/remove.rs
@@ -25,7 +25,6 @@ pub fn remove_project_dependency(
 
     let mut toml = Toml::open(&project.root.join("pyproject.toml"))?;
     toml.remove_dependency(dependency);
-    toml.remove_optional_dependency(dependency);
 
     // Serialize pyproject.toml.
     let string = match toml.to_string() {
@@ -69,13 +68,9 @@ mod tests {
             .iter()
             .any(|d| d.starts_with("click"));
         let existed = existed
-            && toml
-                .project
-                .optional_dependencies
-                .as_ref()
-                .unwrap()
-                .iter()
-                .any(|d| d.starts_with("black"));
+            && toml.project.optional_dependencies.map_or(false, |deps| {
+                deps.values().flatten().any(|d| d.starts_with("pytest"))
+            });
 
         remove_project_dependency(&project, "click").unwrap();
 
@@ -87,13 +82,9 @@ mod tests {
             .any(|s| s.starts_with("click"));
 
         let exists = exists
-            && toml
-                .project
-                .optional_dependencies
-                .as_ref()
-                .unwrap()
-                .iter()
-                .any(|s| s.starts_with("black"));
+            && toml.project.optional_dependencies.map_or(false, |deps| {
+                deps.values().flatten().any(|d| d.starts_with("pytest"))
+            });
 
         assert!(existed);
         assert!(!exists);

--- a/src/huak/project/config.rs
+++ b/src/huak/project/config.rs
@@ -11,7 +11,7 @@ const DEFAULT_SEARCH_STEPS: usize = 5;
 /// Traits for Python-specific configuration.
 pub trait PythonConfig {
     fn package_list(&self) -> Vec<PythonPackage>;
-    fn optional_package_list(&self) -> Vec<PythonPackage>;
+    fn optional_package_list(&self, opt_group: &str) -> Vec<PythonPackage>;
 }
 
 /// `Manifest` data the configuration uses to manage standard configuration
@@ -114,15 +114,16 @@ impl PythonConfig for Config {
     }
     // Get vec of `PythonPackage`s from the manifest.
     // TODO: More than toml.
-    fn optional_package_list(&self) -> Vec<PythonPackage> {
+    fn optional_package_list(&self, group: &str) -> Vec<PythonPackage> {
         // Get huak's spanned table found in the Toml.
         let table = &self.manifest.toml.project;
+        let empty: Vec<String> = vec![];
 
         // Dependencies to list from.
-        let from = match &table.optional_dependencies {
-            Some(vec) => vec,
-            None => return vec![],
-        };
+        let from = &table
+            .optional_dependencies
+            .as_ref()
+            .map_or(&empty, |deps| deps.get(group).unwrap_or(&empty));
 
         // Collect into vector of owned `PythonPackage` data.
         from.iter()


### PR DESCRIPTION
I took a stab at re-implementing optional deps based on https://peps.python.org/pep-0631/#optional-dependencies. LMK if this direction is useful. I wanted to add a test under `src/huak/ops/install.rs` inside the existing one but for some reason it panics and fails.