### PR TITLE
add project type selection in new command

### DIFF
--- a/src/bin/huak/commands/mod.rs
+++ b/src/bin/huak/commands/mod.rs
@@ -72,12 +72,12 @@ pub enum Commands {
     Lint,
     /// Create a project from scratch.
     New {
+        /// Create a library.
+        #[arg(long, conflicts_with = "app")]
+        lib: bool,
         /// Create a runnable application.
         #[arg(long)]
         app: bool,
-        /// Create a library.
-        #[arg(long)]
-        lib: bool,
         path: Option<String>,
     },
     /// Builds and uploads current project to a registry.

--- a/src/bin/huak/commands/mod.rs
+++ b/src/bin/huak/commands/mod.rs
@@ -45,7 +45,7 @@ pub enum Commands {
     Build,
     /// Remove tarball and wheel from the built project.
     Clean,
-    /// Remove all .pyc files and __pycache__ directores.
+    /// Remove all .pyc files and __pycache__ directories.
     #[command(name = "clean-pycache")]
     Cleanpycache,
     /// Builds and uploads current project to a registry.
@@ -60,7 +60,7 @@ pub enum Commands {
         #[arg(long)]
         check: bool,
     },
-    /// Initialize the exi`sting project.
+    /// Initialize the existing project.
     Init,
     /// Install the dependencies of an existing project.
     Install {
@@ -71,7 +71,15 @@ pub enum Commands {
     /// Lint Python code.
     Lint,
     /// Create a project from scratch.
-    New { path: Option<String> },
+    New {
+        /// Create a runnable application.
+        #[arg(long)]
+        app: bool,
+        /// Create a library.
+        #[arg(long)]
+        lib: bool,
+        path: Option<String>,
+    },
     /// Builds and uploads current project to a registry.
     Publish,
     /// Remove a dependency from the project.
@@ -103,7 +111,7 @@ impl Cli {
             Commands::Init => init::run(),
             Commands::Install { all } => install::run(all),
             Commands::Lint => lint::run(),
-            Commands::New { path } => new::run(path),
+            Commands::New { path, app, lib } => new::run(path, app, lib),
             Commands::Publish => publish::run(),
             Commands::Remove { dependency } => remove::run(dependency),
             Commands::Run { command } => run::run(command),

--- a/src/bin/huak/commands/new.rs
+++ b/src/bin/huak/commands/new.rs
@@ -5,13 +5,28 @@ use std::process::ExitCode;
 use huak::errors::{CliError, CliResult, HuakError};
 use huak::ops;
 use huak::project::Project;
+use huak::project::ProjectType;
 
 /// Run the `new` command.
-// TODO: Ops should hanlde the path creation step in addition to the project creation.
-pub fn run(path: Option<String>) -> CliResult<()> {
+// TODO: Ops should handle the path creation step in addition to the project creation.
+pub fn run(path: Option<String>, app: bool, lib: bool) -> CliResult<()> {
     // This command runs from the current working directory
     // Each command's behavior is triggered from the context of the cwd.
     let cwd = env::current_dir()?;
+
+    // The user cannot ask for both kinds of project at once.
+    if app && lib {
+        return Err(CliError::new(
+            HuakError::ConflictingArguments,
+            ExitCode::FAILURE,
+        ));
+    }
+
+    let project_type = match (app, lib) {
+        (true, false) => ProjectType::Application,
+        (false, true) => ProjectType::Library,
+        _ => Default::default(),
+    };
 
     // If a user passes a path
     let path = match path {
@@ -40,7 +55,7 @@ pub fn run(path: Option<String>) -> CliResult<()> {
         fs::create_dir_all(&path)?;
     }
 
-    let project = Project::new(path);
+    let project = Project::new(path, project_type);
 
     if let Err(e) = ops::new::create_project(&project) {
         return Err(CliError::new(e, ExitCode::FAILURE));

--- a/src/bin/huak/commands/new.rs
+++ b/src/bin/huak/commands/new.rs
@@ -14,14 +14,6 @@ pub fn run(path: Option<String>, app: bool, lib: bool) -> CliResult<()> {
     // Each command's behavior is triggered from the context of the cwd.
     let cwd = env::current_dir()?;
 
-    // The user cannot ask for both kinds of project at once.
-    if app && lib {
-        return Err(CliError::new(
-            HuakError::ConflictingArguments,
-            ExitCode::FAILURE,
-        ));
-    }
-
     let project_type = match (app, lib) {
         (true, false) => ProjectType::Application,
         (false, true) => ProjectType::Library,

--- a/src/huak/config/pyproject/project/mod.rs
+++ b/src/huak/config/pyproject/project/mod.rs
@@ -30,6 +30,7 @@ pub(crate) struct Project {
     #[serde(rename = "optional-dependencies")]
     pub(crate) optional_dependencies: Option<HashMap<String, Vec<String>>>,
     pub(crate) authors: Vec<Author>,
+    pub(crate) scripts: Option<HashMap<String, String>>,
 }
 
 impl Default for Project {
@@ -41,6 +42,7 @@ impl Default for Project {
             authors: vec![],
             dependencies: vec![],
             optional_dependencies: None,
+            scripts: None,
         }
     }
 }

--- a/src/huak/errors.rs
+++ b/src/huak/errors.rs
@@ -17,6 +17,7 @@ const BASIC_ERROR_CODE: ExitCode = ExitCode::FAILURE;
 pub enum HuakError {
     NotImplemented,
     MissingArguments,
+    ConflictingArguments,
     UnknownError,
     IOError,
     UnknownCommand,
@@ -58,6 +59,9 @@ impl fmt::Display for CliError {
 
         let error_string = match &self.error {
             HuakError::MissingArguments => "Some arguments were missing.",
+            HuakError::ConflictingArguments => {
+                "Some arguments were conflicting with each other."
+            }
             HuakError::IOError => "An IO error occurred.",
             HuakError::UnknownCommand => {
                 "This is an unknown command. Please check --help."

--- a/src/huak/errors.rs
+++ b/src/huak/errors.rs
@@ -17,7 +17,6 @@ const BASIC_ERROR_CODE: ExitCode = ExitCode::FAILURE;
 pub enum HuakError {
     NotImplemented,
     MissingArguments,
-    ConflictingArguments,
     UnknownError,
     IOError,
     UnknownCommand,
@@ -59,9 +58,6 @@ impl fmt::Display for CliError {
 
         let error_string = match &self.error {
             HuakError::MissingArguments => "Some arguments were missing.",
-            HuakError::ConflictingArguments => {
-                "Some arguments were conflicting with each other."
-            }
             HuakError::IOError => "An IO error occurred.",
             HuakError::UnknownCommand => {
                 "This is an unknown command. Please check --help."

--- a/src/huak/ops/new.rs
+++ b/src/huak/ops/new.rs
@@ -54,7 +54,10 @@ mod tests {
 
     use super::*;
 
-    use crate::utils::test_utils::create_mock_project;
+    use crate::{
+        config::pyproject::toml::Toml, project::ProjectType,
+        utils::test_utils::create_mock_project,
+    };
 
     // TODO
     #[test]
@@ -69,5 +72,21 @@ mod tests {
 
         assert!(!had_toml);
         assert!(toml_path.exists());
+    }
+
+    #[test]
+    fn create_app_project() {
+        let directory = tempdir().unwrap().into_path().to_path_buf();
+        let project = Project::new(directory, ProjectType::Application);
+        let toml_path = project.root.join("pyproject.toml");
+
+        create_project(&project).unwrap();
+        let toml = Toml::open(&toml_path).unwrap();
+
+        assert!(toml.project.scripts.is_some());
+        assert_eq!(
+            toml.project.scripts.unwrap()[&toml.project.name],
+            format!("{}:run", toml.project.name)
+        );
     }
 }

--- a/src/huak/ops/project_utils.rs
+++ b/src/huak/ops/project_utils.rs
@@ -1,10 +1,21 @@
-use crate::{config::pyproject::toml::Toml, project::Project};
+use std::collections::HashMap;
+
+use crate::{
+    config::pyproject::toml::Toml,
+    project::{Project, ProjectType},
+};
 
 /// Create project toml.
 // TODO: Config implementations?
 pub fn create_toml(project: &Project) -> Result<Toml, anyhow::Error> {
     let mut toml = Toml::default();
     let name = crate::utils::path::parse_filename(&project.root)?.to_string();
+
+    if matches!(project.project_type, ProjectType::Application) {
+        let entrypoint = format!("{name}:run");
+        toml.project.scripts = Some(HashMap::from([(name.clone(), entrypoint)]))
+    }
+
     toml.project.name = name;
 
     Ok(toml)

--- a/src/huak/project/mod.rs
+++ b/src/huak/project/mod.rs
@@ -12,8 +12,8 @@ use self::config::Config;
 #[derive(Default)]
 pub enum ProjectType {
     #[default]
-    Application,
     Library,
+    Application,
 }
 
 /// The ``Project`` struct.

--- a/src/huak/project/mod.rs
+++ b/src/huak/project/mod.rs
@@ -6,6 +6,16 @@ use crate::errors::HuakError;
 
 use self::config::Config;
 
+/// There are two kinds of project, application and library.
+/// Application projects usually have one or more entrypoints in the form of
+/// runnable scripts while library projects do not.
+#[derive(Default)]
+pub enum ProjectType {
+    #[default]
+    Application,
+    Library,
+}
+
 /// The ``Project`` struct.
 /// The ``Project`` struct provides and API for maintaining project. The pattern for
 /// implementing a new command may involve creating operations that interacts
@@ -22,6 +32,7 @@ use self::config::Config;
 #[derive(Default)]
 pub struct Project {
     pub root: PathBuf,
+    pub project_type: ProjectType,
     config: Config,
     venv: Option<Venv>,
 }
@@ -36,9 +47,10 @@ impl Project {
     /// let cwd = env::current_dir().unwrap();
     /// let project = Project::from(cwd);
     /// ```
-    pub fn new(path: PathBuf) -> Project {
+    pub fn new(path: PathBuf, project_type: ProjectType) -> Project {
         Project {
             root: path,
+            project_type,
             config: Config::default(),
             venv: None,
         }
@@ -73,8 +85,13 @@ impl Project {
             root = parent.to_path_buf()
         }
 
+        // We can't know the project type here, but it probably doesn't matter
+        // much. We'll just use the default.
+        let project_type = ProjectType::default();
+
         Ok(Project {
             root,
+            project_type,
             config,
             venv: Some(venv),
         })


### PR DESCRIPTION
hi! really interesting project you've got here. in the spirit of hacktoberfest i want to contribute something.

as per #229 i've had a go at adding some flags like cargo's `--bin` and `--lib` options. i went with "app" instead of "bin" as i felt it made more sense in the context of python, but this naming is very much up for discussion.

the PR so far is mostly plumbing and the switches don't do too much right now, though i did make it put a dummy script entrypoint into the pyproject.toml file for `--app` type projects.

the following are some examples of what this change adds.

by default, an "app" type project is created with a script entrypoint:
```
$ huak new myproject       
$ cat myproject/pyproject.toml
...
[project.scripts]
myproject = "myproject:run"
...
```

you can also specify `--app` explicitly if you like for the same result:
```
$ huak new --app myproject      
$ cat myproject/pyproject.toml
...
[project.scripts]
myproject = "myproject:run"
...
```

specifiying `--lib` instead gets you a library-type project with no script entrypoint:
```
$ huak new --lib myproject  
$ cat myproject/pyproject.toml
[project]
name = "myproject"
version = "0.0.1"
description = ""
dependencies = []
authors = []

[build-system]
requires = ["hatchling"]
build-backend = "hatchling.build"
```

and finally you cannot ask for both at the same time:
```
$ huak new --app --lib myproject
Some arguments were conflicting with each other.
```

please let me know what you think of this implementation so far, and what more would need to be done for it to be accepted!

closes #229