### PR TITLE
Publish to PyPI

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,32 @@
+name: Publish to PyPi
+# Notes: This is just for the proof concept phase for huak
+
+# ToDo: multi python version workflow
+
+# ToDo: multi-platform workflow (container based)
+#  openssl = { version = "0.10", features = ["vendored"] }
+#  https://github.com/messense/maturin-action/discussions/78 ass openssl dep
+
+on:
+  push:
+    branches:
+      - '*' # for testing purposes
+      #  release:
+#    types: [published]
+
+jobs:
+  test-rust:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - run: pip install maturin==0.13.5
+      - run: maturin publish --repository testpypi --username __token__ --password ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,32 +1,127 @@
-name: Publish to PyPi
-# Notes: This is just for the proof concept phase for huak
+name: Build and Publish to PyPI
+# see https://github.com/messense/crfs-rs/blob/main/.github/workflows/Python.yml
 
-# ToDo: multi python version workflow
-
-# ToDo: multi-platform workflow (container based)
-#  openssl = { version = "0.10", features = ["vendored"] }
-#  https://github.com/messense/maturin-action/discussions/78 ass openssl dep
 
 on:
-  push:
-    branches:
-      - '*' # for testing purposes
-      #  release:
-#    types: [published]
+  release:
+    types: [published]
 
+# This workflow builds huak as pip/python 'wheels' which are platform and python version specific.
+# when installed via PyPI, Pip will download the wheel for the user's system if we support it through this workflow.
 jobs:
-  test-rust:
-    name: Build and Publish
+  # The 'linux' job uses the manylinux docker image to build wheels that can be used by most linux distros.
+  linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # These are the CPU architectures...
+        target: [ x86_64, i686 ]
+        # and python versions we'll support on linux.
+        # see https://github.com/pypa/manylinux for info on supported python versions.
+        py-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
+      - name: build wheels
+        # see example at https://github.com/messense/crfs-rs/blob/main/.github/workflows/Python.yml
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          maturin-version: latest
+          # Maturin's default command is 'build',
+          # and target supported python version ('-i' flag) and store in dist, so we can upload all wheels at same time.
+          args: --release -i ${{ matrix.py-version }} --out dist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+
+  # Windows job is pretty straight forward, no containers. Runs on Windows, for Windows.
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [ x64, x86 ]
+        py-version: [ '3.7', '3.8', '3.9', '3.10' ]
+    steps:
+      - uses: actions/checkout@v2
+        # since we don't have a requirements.txt file in the project root, setup-python needs one.
+      - name: check requirements.txt
+        run: |
+          if (!(Test-Path requirements.txt))
+          {
+          New-Item -itemType File -Name requirements.txt
+          }
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
-          cache: "pip"
-      - uses: actions-rs/toolchain@v1
+          python-version: '3.10'
+          architecture: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-      - run: pip install maturin==0.13.5
-      - run: maturin publish --repository testpypi --username __token__ --password ${{ secrets.PYPI_PASSWORD }}
+          profile: minimal
+          default: true
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          maturin-version: latest
+          args: --release -i ${{ matrix.py-version }} --out dist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        # since we don't have a requirements.txt file in the project root, setup-python needs one.
+      - name: check requirements.txt
+        run: |
+          if [[ ! -f requirements.txt ]]; then
+            touch requirements.txt
+          fi
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
+      - name: Build wheels - universal2
+        uses: messense/maturin-action@v1
+        with:
+          args: --release --universal2 --out dist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [ macos, linux, windows ]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          # use 'twine upload --repository testpypi --skip-existing *' to upload to http://test.pypi.org
+        run: |
+          pip install --upgrade twine
+          twine upload --skip-existing *

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "clap",
  "fs_extra",
  "glob",
+ "openssl",
  "pyo3",
  "reqwest",
  "serde",
@@ -537,6 +538,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +555,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "clap",
  "fs_extra",
  "glob",
+ "pyo3",
  "reqwest",
  "serde",
  "serde_derive",
@@ -370,6 +371,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +442,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -530,6 +556,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +633,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f72538a0230791398a0986a6518ebd88abc3fded89007b506ed072acc831e1"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4cf18c20f4f09995f3554e6bcf9b09bd5e4d6b67c562fdfaafa644526ba479"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41877f28d8ebd600b6aa21a17b40c3b0fc4dfe73a27b6e81ab3d895e401b0e9"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e81c8d4bcc2f216dc1b665412df35e46d12ee8d3d046b381aad05f1fcf30547"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85752a767ee19399a78272cc2ab625cd7d373b2e112b4b13db28de71fa892784"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -667,6 +776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +854,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +885,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 
 [[package]]
 name = "tempfile"
@@ -906,6 +1033,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unindent"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ serde = "1.0.144"
 serde_derive = "1.0.144"
 toml = "0.5.9"
 serde_json = "1.0"
-reqwest = { version = "0.11", features = ["blocking", "json"] } 
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+pyo3 = { version = "0.17.1", features = ["abi3"] }
+openssl = { version = "0.10", features = ["vendored"] } # included to build PyPi Wheels (see .github/workflow/README.md)
 
 [dev-dependencies]
 tempfile = "3.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "huak"
+version = "0.0.203"
+description = "A Python package manager written in Rust inspired by Cargo."
+authors = [
+    {email = "cnpryer@gmail.com"},
+    {name = "Chris Pryer"}
+]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Rust",
+]
+
+[project.urls]
+Issues = "https://github.com/cnpryer/huak/issues"
+Documentation = "https://docs.rs/crate/huak"
+homepage = "https://github.com/cnpryer/huak"
+repository = "https://github.com/cnpryer/huak"
+
+[tool.maturin]
+bindings = "bin"
+
+[build-system]
+requires = ["maturin>=0.13,<0.14"]
+build-backend = "maturin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "huak"
-version = "0.0.203"
+version = "0.0.4a0"
 description = "A Python package manager written in Rust inspired by Cargo."
 authors = [
     {email = "cnpryer@gmail.com"},


### PR DESCRIPTION
This PR adds configs to the project and a new GitHub actions workflow that
publishes the huak command line tool to PyPI whenever a release is published.


This was way more involved than I thought, the Build and Publish to PyPI pipeline creates 17 different wheels to install on windows, macos (arm64 and x86_64), linux for python versions 3.7 through 3.10. 


*Not sure if the universal2 wheel will work for macos python version 3.7 - 3.9* but that can be fixed. I have tested on linux, macos (arm64) and windows via test PyPI here https://test.pypi.org/project/huak/


## Necessary adjustments before accepting this PR
1. Create a API token for the huak project on [PyPi](https://pypi.org/)
- it should probably have a limited scope to huak, but it needs upload permissions.
2. Add a GitHub secret name PYPI_PASSWORD equal to the complete API token from step 1.

closes #261

TBH i'm not sure maturin has the ability distribute a bin and extension module (python binding via huak-py like we talked about) in the same wheel. But either way, that is definitely a separate PR. We can cross that bridge when we get there. 
