### PR TITLE
Allow installing specific optional dependency groups via the cli

### DIFF
--- a/src/bin/huak/commands/install.rs
+++ b/src/bin/huak/commands/install.rs
@@ -6,14 +6,18 @@ use huak::ops;
 use huak::project::Project;
 
 /// Run the `install` command.
-pub fn run(all: bool) -> CliResult<()> {
+pub fn run(groups: Option<Vec<String>>, all: bool) -> CliResult<()> {
     let cwd = env::current_dir()?;
     let project = match Project::from(cwd) {
         Ok(p) => p,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
 
-    if let Err(e) = ops::install::install_project_dependencies(&project, all) {
+    if let Err(e) = ops::install::install_project_dependencies(
+        &project,
+        &groups.unwrap_or_default(),
+        all,
+    ) {
         return Err(CliError::new(e, ExitCode::FAILURE));
     };
 

--- a/src/bin/huak/commands/mod.rs
+++ b/src/bin/huak/commands/mod.rs
@@ -64,6 +64,9 @@ pub enum Commands {
     Init,
     /// Install the dependencies of an existing project.
     Install {
+        /// Install optional dependency groups
+        #[arg(long, conflicts_with = "all", num_args = 1..)]
+        groups: Option<Vec<String>>,
         /// Install main and all optional dependencies.
         #[arg(long)]
         all: bool,
@@ -109,7 +112,7 @@ impl Cli {
             Commands::Doc { check } => doc::run(check),
             Commands::Fmt { check } => fmt::run(check),
             Commands::Init => init::run(),
-            Commands::Install { all } => install::run(all),
+            Commands::Install { groups, all } => install::run(groups, all),
             Commands::Lint => lint::run(),
             Commands::New { path, app, lib } => new::run(path, app, lib),
             Commands::Publish => publish::run(),


### PR DESCRIPTION
Closes #264

I went with the syntax `huak install --groups group1,group2,..`, somewhat similar to poetry's `poetry install --only group1,group2,..`.