### PR TITLE
Bump to v0.0.5-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "huak"
-version = "0.0.4-alpha.1"
+version = "0.0.5-alpha.1"
 dependencies = [
  "clap",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huak"
-version = "0.0.4-alpha.1"
+version = "0.0.5-alpha.1"
 edition = "2021"
 license = "MIT"
 description = "A Python package manager written in Rust inspired by Cargo."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "huak"
-version = "0.0.4a0"
+version = "0.0.5-alpha.1"
 description = "A Python package manager written in Rust inspired by Cargo."
 authors = [
     {email = "cnpryer@gmail.com"},


### PR DESCRIPTION
Expecting a v0.0.5-alpha.2 with pyproject-toml-rs enabled
