### PR TITLE
basic fix command

### DIFF
--- a/src/bin/huak/commands/fix.rs
+++ b/src/bin/huak/commands/fix.rs
@@ -1,0 +1,23 @@
+use crate::errors::CliError;
+use huak::ops;
+use huak::project::Project;
+use std::env;
+use std::process::ExitCode;
+
+use crate::errors::CliResult;
+
+/// Run the `fix` command.
+pub fn run() -> CliResult<()> {
+    // This command runs from the context of the cwd.
+    let cwd = env::current_dir()?;
+    let project = match Project::from(cwd) {
+        Ok(p) => p,
+        Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
+    };
+
+    if let Err(e) = ops::fix::fix_project(&project) {
+        return Err(CliError::new(e, ExitCode::FAILURE));
+    };
+
+    Ok(())
+}

--- a/src/bin/huak/commands/mod.rs
+++ b/src/bin/huak/commands/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod build;
 pub(crate) mod clean;
 pub(crate) mod clean_pycache;
 pub(crate) mod doc;
+pub(crate) mod fix;
 pub(crate) mod fmt;
 pub(crate) mod init;
 pub(crate) mod install;
@@ -54,6 +55,8 @@ pub enum Commands {
         #[arg(long)]
         check: bool,
     },
+    /// Auto-Fix Lint Conflicts
+    Fix,
     /// Format Python code.
     Fmt {
         /// Check if Python code is formatted.
@@ -107,6 +110,7 @@ impl Cli {
             Commands::Clean => clean::run(),
             Commands::Cleanpycache => clean_pycache::run(),
             Commands::Doc { check } => doc::run(check),
+            Commands::Fix => fix::run(),
             Commands::Fmt { check } => fmt::run(check),
             Commands::Init => init::run(),
             Commands::Install { all } => install::run(all),

--- a/src/huak/ops/fix.rs
+++ b/src/huak/ops/fix.rs
@@ -1,0 +1,17 @@
+use crate::{
+    errors::{HuakError, HuakResult},
+    project::Project,
+};
+
+const MODULE: &str = "ruff";
+
+/// Fixes the lint error the project from its root.
+pub fn fix_project(project: &Project) -> HuakResult<()> {
+    let venv = match project.venv() {
+        Some(v) => v,
+        _ => return Err(HuakError::VenvNotFound),
+    };
+    let args = [".", "--fix", "--extend-exclude", venv.name()?];
+
+    venv.exec_module(MODULE, &args, &project.root)
+}

--- a/src/huak/ops/fix.rs
+++ b/src/huak/ops/fix.rs
@@ -15,3 +15,52 @@ pub fn fix_project(project: &Project) -> HuakResult<()> {
 
     venv.exec_module(MODULE, &args, &project.root)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    use crate::utils::{
+        path::copy_dir,
+        test_utils::{create_mock_project, get_resource_dir},
+    };
+
+    #[test]
+    fn fix() {
+        let directory = tempdir().unwrap().into_path().to_path_buf();
+        let mock_project_dir = get_resource_dir().join("mock-project");
+        copy_dir(&mock_project_dir, &directory);
+
+        let project_path = directory.join("mock-project");
+        let project = create_mock_project(project_path.clone()).unwrap();
+        project
+            .venv()
+            .as_ref()
+            .unwrap()
+            .exec_module("pip", &["install", MODULE], &project.root)
+            .unwrap();
+
+        let lint_fix_filepath = project
+            .root
+            .join("src")
+            .join("mock_project")
+            .join("fix_me.py");
+        let pre_fix_str = r##"""
+import json # this gets removed(autofixed)
+
+
+def fn():
+    pass"##;
+
+        fs::write(&lint_fix_filepath, pre_fix_str).unwrap();
+        fix_project(&project).unwrap();
+        let post_fix_str = fs::read_to_string(&lint_fix_filepath).unwrap();
+        println!("{}", post_fix_str);
+
+        assert_ne!(pre_fix_str, post_fix_str);
+    }
+}

--- a/src/huak/ops/mod.rs
+++ b/src/huak/ops/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod build;
 pub mod clean;
+pub mod fix;
 pub mod fmt;
 pub mod init;
 pub mod install;


### PR DESCRIPTION
Fixes #74,

![image](https://user-images.githubusercontent.com/85608760/194308026-13aa8bba-18bf-4ce3-bb52-caa9337d60da.png)
There's also this issue where `ruff` returns a non-zero exit code upon auto-fixing the lint errors, which throws an error in our case(after fixing lints), Any idea how to deal with this, should we modify our error message?
```
No pyproject.toml found.
Falling back to default configuration...
Found 0 error(s) (65 fixed).
hauk exited with code ExitCode(unix_exit_status(1)): An unknown error occurred: . Please file a bug report at https://github.com/cnpryer/huak/issues/new?assignees=&labels=bug&template=BUG_REPORT.md&title=
```