### PR TITLE
Add pypi badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![ci-rust](https://github.com/cnpryer/huak/actions/workflows/ci-rust.yaml/badge.svg)](https://github.com/cnpryer/huak/actions/workflows/ci-rust.yaml)
 [![ci-python](https://github.com/cnpryer/huak/actions/workflows/ci-python.yaml/badge.svg)](https://github.com/cnpryer/huak/actions/workflows/ci-python.yaml)
+[![pypi.org](https://img.shields.io/pypi/v/huak.svg)](https://pypi.org/project/huak/)
 [![crates.io](https://img.shields.io/crates/v/huak.svg)](https://crates.io/crates/huak)
 [![discord](https://img.shields.io/discord/1022879330470199347?color=7289DA&logo=discord)](https://discord.gg/St3menxFZT)
 


### PR DESCRIPTION
I want this, but pypi seems reluctant to publish latest non-production-ready release versions ahead of latest production-ready. I don't really want to have 0.0.0 sitting on the README since it makes it seem like there's nothing available on pypi when there is.

For this reason I'll leave this as a draft.