### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,13 +33,13 @@ MANIFEST
 .vscode/
 
 # Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
+/.env
+/.venv
+/env/
+/venv/
+/ENV/
+/env.bak/
+/venv.bak/
 
 # Misc.
 .DS_Store


### PR DESCRIPTION
`.gitignore` was matching `src/huak/env` folder, so I re-included it.
Alternatively we could make venv dir matching more specific (e.g. only match them in root directory and/or `huak-py`). Should be fine either way.
Or we could remove matching `env/` altogether, because pretty much no one uses that AFAIK ;)
Let me know what would you prefer!