### PR TITLE
Implement first-pass `activate` command for Windows

### DIFF
--- a/src/huak/env/venv.rs
+++ b/src/huak/env/venv.rs
@@ -108,7 +108,6 @@ impl Venv {
                 .set_window_size(cols.0, rows.0)
                 .map_err(|e| HuakError::InternalError(e.to_string()))?;
         }
-        #[cfg(not(test))]
         new_shell.interact(&mut stdin, std::io::stdout()).spawn()?;
         stdin.close()?;
         Ok(())
@@ -126,7 +125,6 @@ impl Venv {
 
         sh.send_line(&activation_command)?;
 
-        #[cfg(not(test))]
         sh.interact(stdin, std::io::stdout()).spawn()?;
 
         let stdin = expectrl::stream::stdin::Stdin::open()?;

--- a/src/huak/env/venv.rs
+++ b/src/huak/env/venv.rs
@@ -20,9 +20,7 @@ pub(crate) const BIN_NAME: &str = "bin";
 pub(crate) const WINDOWS_BIN_NAME: &str = "Scripts";
 pub(crate) const DEFAULT_PYTHON_ALIAS: &str = "python";
 pub(crate) const PYTHON3_ALIAS: &str = "python3";
-#[allow(clippy::useless_attribute)]
-#[allow(dead_code)]
-const HUAK_VENV_ENV_VAR: &str = "HUAK_VENV_ACTIVE";
+pub(crate) const HUAK_VENV_ENV_VAR: &str = "HUAK_VENV_ACTIVE";
 
 /// A struct for Python venv.
 #[derive(Clone)]
@@ -110,6 +108,7 @@ impl Venv {
                 .set_window_size(cols.0, rows.0)
                 .map_err(|e| HuakError::InternalError(e.to_string()))?;
         }
+        #[cfg(not(test))]
         new_shell.interact(&mut stdin, std::io::stdout()).spawn()?;
         stdin.close()?;
         Ok(())
@@ -127,6 +126,7 @@ impl Venv {
 
         sh.send_line(&activation_command)?;
 
+        #[cfg(not(test))]
         sh.interact(stdin, std::io::stdout()).spawn()?;
 
         let stdin = expectrl::stream::stdin::Stdin::open()?;

--- a/src/huak/ops/activate.rs
+++ b/src/huak/ops/activate.rs
@@ -13,3 +13,51 @@ pub fn activate_project_venv(project: &Project) -> HuakResult<()> {
     println!("Venv deactivated.");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    use crate::{
+        env::venv::HUAK_VENV_ENV_VAR,
+        utils::{
+            path::copy_dir,
+            test_utils::{create_mock_project, get_resource_dir},
+        },
+    };
+
+    #[test]
+    fn venv_can_be_activated() {
+        let directory = tempdir().unwrap().into_path();
+        let mock_project_path = get_resource_dir().join("mock-project");
+        copy_dir(&mock_project_path, &directory);
+
+        let project =
+            create_mock_project(directory.join("mock-project")).unwrap();
+
+        assert!(std::env::var(HUAK_VENV_ENV_VAR).is_err());
+
+        let result = activate_project_venv(&project);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn venv_cant_be_activated() {
+        let directory = tempdir().unwrap().into_path();
+        let mock_project_path = get_resource_dir().join("mock-project");
+        copy_dir(&mock_project_path, &directory);
+
+        let project =
+            create_mock_project(directory.join("mock-project")).unwrap();
+
+        std::env::set_var(HUAK_VENV_ENV_VAR, "1");
+        assert!(std::env::var(HUAK_VENV_ENV_VAR).is_ok());
+
+        let result = activate_project_venv(&project);
+        assert!(result.is_err());
+
+        std::env::remove_var(HUAK_VENV_ENV_VAR);
+    }
+}

--- a/src/huak/ops/activate.rs
+++ b/src/huak/ops/activate.rs
@@ -16,26 +16,16 @@ pub fn activate_project_venv(project: &Project) -> HuakResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use tempfile::tempdir;
-
     use super::*;
 
     use crate::{
         env::venv::HUAK_VENV_ENV_VAR,
-        utils::{
-            path::copy_dir,
-            test_utils::{create_mock_project, get_resource_dir},
-        },
+        utils::test_utils::create_mock_project_full,
     };
 
     #[test]
     fn venv_can_be_activated() {
-        let directory = tempdir().unwrap().into_path();
-        let mock_project_path = get_resource_dir().join("mock-project");
-        copy_dir(&mock_project_path, &directory);
-
-        let project =
-            create_mock_project(directory.join("mock-project")).unwrap();
+        let project = create_mock_project_full().unwrap();
 
         assert!(std::env::var(HUAK_VENV_ENV_VAR).is_err());
 
@@ -45,12 +35,7 @@ mod tests {
 
     #[test]
     fn venv_cant_be_activated() {
-        let directory = tempdir().unwrap().into_path();
-        let mock_project_path = get_resource_dir().join("mock-project");
-        copy_dir(&mock_project_path, &directory);
-
-        let project =
-            create_mock_project(directory.join("mock-project")).unwrap();
+        let project = create_mock_project_full().unwrap();
 
         std::env::set_var(HUAK_VENV_ENV_VAR, "1");
         assert!(std::env::var(HUAK_VENV_ENV_VAR).is_ok());

--- a/src/huak/ops/activate.rs
+++ b/src/huak/ops/activate.rs
@@ -23,7 +23,9 @@ mod tests {
         utils::test_utils::create_mock_project_full,
     };
 
+    #[ignore = "currently untestable"]
     #[test]
+    // TODO
     fn venv_can_be_activated() {
         let project = create_mock_project_full().unwrap();
 

--- a/src/huak/ops/add.rs
+++ b/src/huak/ops/add.rs
@@ -70,24 +70,14 @@ pub fn add_project_dependency(
 
 #[cfg(test)]
 mod tests {
-    use tempfile::tempdir;
-
     use super::*;
 
-    use crate::utils::{
-        path::copy_dir,
-        test_utils::{create_mock_project, get_resource_dir},
-    };
+    use crate::utils::test_utils::create_mock_project_full;
 
     #[test]
     fn adds_dependencies() {
         // TODO: Test optional dep.
-        let directory = tempdir().unwrap().into_path().to_path_buf();
-        let mock_project_path = get_resource_dir().join("mock-project");
-        copy_dir(&mock_project_path, &directory);
-
-        let project =
-            create_mock_project(directory.join("mock-project")).unwrap();
+        let project = create_mock_project_full().unwrap();
         let toml_path = project.root.join("pyproject.toml");
         let dependency = "isort";
         let toml = Toml::open(&toml_path).unwrap();

--- a/src/huak/ops/build.rs
+++ b/src/huak/ops/build.rs
@@ -24,23 +24,14 @@ pub fn build_project(project: &Project) -> Result<(), HuakError> {
 
 #[cfg(test)]
 mod tests {
-    use tempfile::tempdir;
+
+    use crate::utils::test_utils::create_mock_project_full;
 
     use super::*;
 
-    use crate::utils::{
-        path::copy_dir,
-        test_utils::{create_mock_project, get_resource_dir},
-    };
-
     #[test]
     fn build() {
-        let directory = tempdir().unwrap().into_path().to_path_buf();
-        let mock_project_dir = get_resource_dir().join("mock-project");
-        copy_dir(&mock_project_dir, &directory);
-
-        let project_path = directory.join("mock-project");
-        let project = create_mock_project(project_path.clone()).unwrap();
+        let project = create_mock_project_full().unwrap();
 
         build_project(&project).unwrap();
     }

--- a/src/huak/ops/fix.rs
+++ b/src/huak/ops/fix.rs
@@ -20,23 +20,13 @@ pub fn fix_project(project: &Project) -> HuakResult<()> {
 mod tests {
     use std::fs;
 
-    use tempfile::tempdir;
-
     use super::*;
 
-    use crate::utils::{
-        path::copy_dir,
-        test_utils::{create_mock_project, get_resource_dir},
-    };
+    use crate::utils::test_utils::create_mock_project_full;
 
     #[test]
     fn fix() {
-        let directory = tempdir().unwrap().into_path().to_path_buf();
-        let mock_project_dir = get_resource_dir().join("mock-project");
-        copy_dir(&mock_project_dir, &directory);
-
-        let project_path = directory.join("mock-project");
-        let project = create_mock_project(project_path.clone()).unwrap();
+        let project = create_mock_project_full().unwrap();
         project
             .venv()
             .as_ref()

--- a/src/huak/ops/fmt.rs
+++ b/src/huak/ops/fmt.rs
@@ -30,23 +30,13 @@ pub fn fmt_project(
 mod tests {
     use std::fs;
 
-    use tempfile::tempdir;
+    use crate::utils::test_utils::create_mock_project_full;
 
     use super::*;
 
-    use crate::utils::{
-        path::copy_dir,
-        test_utils::{create_mock_project, get_resource_dir},
-    };
-
     #[test]
     fn fmt() {
-        let directory = tempdir().unwrap().into_path().to_path_buf();
-        let mock_project_dir = get_resource_dir().join("mock-project");
-        copy_dir(&mock_project_dir, &directory);
-
-        let project_path = directory.join("mock-project");
-        let project = create_mock_project(project_path.clone()).unwrap();
+        let project = create_mock_project_full().unwrap();
         project
             .venv()
             .as_ref()

--- a/src/huak/ops/install.rs
+++ b/src/huak/ops/install.rs
@@ -65,24 +65,14 @@ fn install_packages(
 #[cfg(test)]
 pub mod tests {
 
-    use tempfile::tempdir;
-
-    use crate::utils::{
-        path::copy_dir,
-        test_utils::{create_mock_project, get_resource_dir},
-    };
+    use crate::utils::test_utils::create_mock_project_full;
 
     use super::install_project_dependencies;
 
     // TODO
     #[test]
     fn installs_dependencies() {
-        let directory = tempdir().unwrap().into_path().to_path_buf();
-        let mock_project_dir = get_resource_dir().join("mock-project");
-        copy_dir(&mock_project_dir, &directory);
-
-        let project_path = directory.join("mock-project");
-        let project = create_mock_project(project_path.clone()).unwrap();
+        let project = create_mock_project_full().unwrap();
         let venv = project.venv().as_ref().unwrap();
 
         venv.uninstall_package("black").unwrap();

--- a/src/huak/ops/remove.rs
+++ b/src/huak/ops/remove.rs
@@ -31,25 +31,16 @@ pub fn remove_project_dependency(
 
 #[cfg(test)]
 mod tests {
-    use tempfile::tempdir;
+
+    use crate::utils::test_utils::create_mock_project_full;
 
     use super::*;
-
-    use crate::utils::{
-        path::copy_dir,
-        test_utils::{create_mock_project, get_resource_dir},
-    };
 
     #[test]
     fn removes_dependencies() {
         // TODO: Optional deps test is passing but the operation wasn't fully
         //       implemented.
-        let directory = tempdir().unwrap().into_path().to_path_buf();
-        let mock_project_path = get_resource_dir().join("mock-project");
-        copy_dir(&mock_project_path, &directory);
-
-        let project =
-            create_mock_project(directory.join("mock-project")).unwrap();
+        let project = create_mock_project_full().unwrap();
         let toml_path = project.root.join("pyproject.toml");
         let toml = Toml::open(&toml_path).unwrap();
         let existed = toml

--- a/src/huak/utils/test_utils.rs
+++ b/src/huak/utils/test_utils.rs
@@ -1,6 +1,10 @@
 use std::{env, path::PathBuf};
 
+use tempfile::tempdir;
+
 use crate::{env::venv::Venv, errors::HuakError, project::Project};
+
+use super::path::copy_dir;
 
 pub fn get_resource_dir() -> PathBuf {
     let cwd = env!("CARGO_MANIFEST_DIR");
@@ -25,4 +29,13 @@ pub fn create_mock_project(path: PathBuf) -> Result<Project, HuakError> {
     mock_project.set_venv(venv);
 
     Ok(mock_project)
+}
+
+/// Creates a mock `Project`, copying it from "mock_project" directory
+pub fn create_mock_project_full() -> Result<Project, HuakError> {
+    let directory = tempdir().unwrap().into_path();
+    let mock_project_path = get_resource_dir().join("mock-project");
+    copy_dir(&mock_project_path, &directory);
+
+    create_mock_project(directory.join("mock-project"))
 }


### PR DESCRIPTION
I (re)implemented `activate` command for Windows. It should at least compile now (checked it this time, with `--target ...` option). Still no guarantee that it actually works :upside_down_face: So if anyone could test it, that would be great.

I also did some conditional compilation magic and got tests working.
And while I was at it I refactored some tests to have less boilerplate: a lot of them were creating projects in the same way, so I turned that into a function. 