### PR TITLE
Ci fixes

### DIFF
--- a/.github/workflows/build-publish-pypi.yaml
+++ b/.github/workflows/build-publish-pypi.yaml
@@ -1,10 +1,14 @@
 name: Build and Publish to PyPI
+# This workflow is a reusable component that handles building python wheels and uploading them to PyPI
 # see https://github.com/messense/crfs-rs/blob/main/.github/workflows/Python.yml
 
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    secrets:
+      PYPI_PASSWORD:
+        description: 'PyPI API token with necessary permissions'
+        required: true
 
 # This workflow builds huak as pip/python 'wheels' which are platform and python version specific.
 # when installed via PyPI, Pip will download the wheel for the user's system if we support it through this workflow.
@@ -21,6 +25,7 @@ jobs:
         py-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
+
       - name: build wheels
         # see example at https://github.com/messense/crfs-rs/blob/main/.github/workflows/Python.yml
         uses: messense/maturin-action@v1
@@ -31,6 +36,7 @@ jobs:
           # Maturin's default command is 'build',
           # and target supported python version ('-i' flag) and store in dist, so we can upload all wheels at same time.
           args: --release -i ${{ matrix.py-version }} --out dist
+
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -46,7 +52,8 @@ jobs:
         target: [ x64, x86 ]
         py-version: [ '3.7', '3.8', '3.9', '3.10' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
         # since we don't have a requirements.txt file in the project root, setup-python needs one.
       - name: check requirements.txt
         run: |
@@ -54,23 +61,27 @@ jobs:
           {
           New-Item -itemType File -Name requirements.txt
           }
-      - uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           architecture: ${{ matrix.target }}
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           default: true
+
       - name: Build wheels
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           maturin-version: latest
           args: --release -i ${{ matrix.py-version }} --out dist
-      - name: Upload wheels
+
+      - name: Save wheels
         uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -79,26 +90,32 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
         # since we don't have a requirements.txt file in the project root, setup-python needs one.
       - name: check requirements.txt
         run: |
           if [[ ! -f requirements.txt ]]; then
             touch requirements.txt
           fi
-      - uses: actions/setup-python@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           default: true
+
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
           args: --release --universal2 --out dist
+
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -111,12 +128,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ macos, linux, windows ]
     steps:
-      - uses: actions/download-artifact@v2
+      - name: Download Saved artifacts
+        uses: actions/download-artifact@v2
         with:
           name: wheels
-      - uses: actions/setup-python@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -1,4 +1,5 @@
-name: ci-python
+name: Python CI Pipeline
+# This top level workflow controls the what and when of the CI pipeline for Python components of huak
 
 on:
   push:
@@ -19,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ['3.9', '3.10']
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -1,6 +1,8 @@
-name: ci-rust
+name: Rust CI Pipeline
+# This top level workflow controls the what and when of the CI pipeline for Rust components of huak
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"
@@ -17,41 +19,5 @@ on:
       - '.github/workflows/ci-rust.yaml'
 
 jobs:
-  test-rust:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    name: Build and test Rust
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: /github/home/.cargo
-          key: cargo-cache-test-rs
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: /github/home/target
-          key: rust-deps-cache-test-rs
-      - name: Run formatting checks
-        run: |
-          cargo fmt --all -- --check
-      - name: Run lints
-        env:
-          RUSTFLAGS: -C debuginfo=0
-        run: |
-            cargo clippy --all-features
-            cargo clippy -- -D warnings
-      - name: Run tests
-        env:
-          HUAK_MUTE_COMMAND: 1
-        run: |
-            cargo test --all-features -- --test-threads=1
+  run-rust-tests:
+    uses: ./.github/workflows/test-rust.yaml

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -1,0 +1,20 @@
+name: Tasks on release
+# This top level GH Action Workflow controls what tasks on run when a release is triggered.
+
+on:
+  push:
+    branches:
+      - "*"
+#on:
+#  release:
+#    types: [published]
+
+jobs:
+  run-rust-tests:
+    uses: ./.github/workflows/test-rust.yaml
+
+  publish-to-pypi:
+    needs: run-rust-tests
+    uses: ./.github/workflows/build-publish-pypi.yaml
+    secrets:
+      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -2,12 +2,8 @@ name: Tasks on release
 # This top level GH Action Workflow controls what tasks on run when a release is triggered.
 
 on:
-  push:
-    branches:
-      - "*"
-#on:
-#  release:
-#    types: [published]
+  release:
+    types: [published]
 
 jobs:
   run-rust-tests:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -1,0 +1,53 @@
+name: Test Rust
+# This workflow does one thing, build and test huak via Cargo.
+# it's a reusable component that is called from other workflows such as the Rust CI Pipeline
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test-rust:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    name: Build and test Rust
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cache Cargo
+        uses: actions/cache@v3
+        with:
+          path: /github/home/.cargo
+          key: cargo-cache-test-rs
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: /github/home/target
+          key: rust-deps-cache-test-rs
+
+      - name: Run formatting checks
+        run: |
+          cargo fmt --all -- --check
+
+      - name: Run lints
+        env:
+          RUSTFLAGS: -C debuginfo=0
+        run: |
+          cargo clippy --all-features
+          cargo clippy -- -D warnings
+
+      - name: Run tests
+        env:
+          HUAK_MUTE_COMMAND: 1
+        run: |
+          cargo test --all-features -- --test-threads=1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # huak
 
-<div align="center">
+<div style="text-align: center">
 
 <a href="https://docs.rs/crate/huak"><img src="docs/assets/img/logo.png" alt="Huak logo" width="300" role="img"></a>
 

--- a/huak-py/Makefile
+++ b/huak-py/Makefile
@@ -9,7 +9,7 @@ help:
 	@echo "  clean				remove cleanable files"
 	@echo "  lint				run flake8 linting"
 	@cheo "  lint-types			run mypy check"
-	@echo "  fmt				run formaters"
+	@echo "  fmt				run formatters"
 	@echo "  fmt-check			run formatting check"
 	@echo "  test				run all tests"
 	@echo "  pre-commit			run pre-commit standardization"

--- a/src/bin/huak/commands/clean_pycache.rs
+++ b/src/bin/huak/commands/clean_pycache.rs
@@ -70,7 +70,7 @@ pub fn run() -> CliResult<()> {
     } else {
         Err(CliError::new(
             _error.unwrap_or_else(|| {
-                HuakError::UnknownError("An unknown error ocurred".into())
+                HuakError::UnknownError("An unknown error occurred".into())
             }),
             ExitCode::FAILURE,
         ))

--- a/src/bin/huak/commands/mod.rs
+++ b/src/bin/huak/commands/mod.rs
@@ -52,7 +52,7 @@ pub enum Commands {
         /// Remove all .pyc files and __pycache__ directories.
         pycache: bool,
     },
-    /// Generates documenation for the project.
+    /// Generates documentation for the project.
     Doc {
         #[arg(long)]
         check: bool,

--- a/src/bin/huak/errors.rs
+++ b/src/bin/huak/errors.rs
@@ -28,7 +28,7 @@ impl std::fmt::Display for CliError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "hauk exited with code {:?}: {}",
+            "huak exited with code {:?}: {}",
             self.exit_code, self.error
         )
     }

--- a/src/huak/env/venv.rs
+++ b/src/huak/env/venv.rs
@@ -216,7 +216,7 @@ impl Venv {
         }
     }
 
-    /// Run a module installed to the venv as an alias'd command from the current working dir.
+    /// Run a module installed to the venv as an aliased command from the current working dir.
     pub fn exec_module(
         &self,
         module: &str,

--- a/src/huak/errors.rs
+++ b/src/huak/errors.rs
@@ -61,7 +61,7 @@ pub enum HuakError {
     #[error("Expected env var not found.")]
     EnvVarError(#[from] std::env::VarError),
     #[error("A pyproject.toml could not be found.")]
-    PyProjectTomlNotFound, // TODO: Manfiest
+    PyProjectTomlNotFound, // TODO: Manifest
     #[error("Failed to install Python package: {0}.")]
     PyPackageInstallFailure(String),
     #[error("A pyproject.toml already exists.")]

--- a/src/huak/project/pyproject.rs
+++ b/src/huak/project/pyproject.rs
@@ -10,7 +10,7 @@ use std::fs;
 use crate::{config::pyproject::toml::Toml, errors::HuakResult};
 
 /// There are two kinds of project, application and library.
-/// Application projects usually have one or more entrypoints in the form of
+/// Application projects usually have one or more entrypoint(s) in the form of
 /// runnable scripts while library projects do not.
 #[derive(Default, Eq, PartialEq)]
 pub enum ProjectType {

--- a/src/huak/utils/command.rs
+++ b/src/huak/utils/command.rs
@@ -33,7 +33,7 @@ fn should_mute() -> bool {
     matches!(_mute.as_str(), "TRUE" | "True" | "true" | "1")
 }
 
-/// Run initilized command with .output() to mute stdout.
+/// Run initialized command with .output() to mute stdout.
 fn run_command_with_output(
     cmd: &str,
     args: &[&str],


### PR DESCRIPTION
This is a pretty simple PR, it just separates 2 parts of our current CI into reusable components.
1. test-rust.yaml --> houses the Rust tests
    - Then it can be called from the ci-rust.yaml AND the on-release.yaml. 
    - on-relese now calls the test rust workflow before building wheels
    - it'll also be a little easier to add workflow components such as publishing to brew or whatever the future holds. 
2. Went through and fixed a handful of inconsequential typos. 