### PR TITLE
Handle errors in `activate` better

### DIFF
--- a/src/huak/env/venv.rs
+++ b/src/huak/env/venv.rs
@@ -155,7 +155,7 @@ impl Venv {
 
         Ok(path)
     }
-    /// Create the venv at its path.
+    /// Create the venv at its path. No-op if it already exists.
     pub fn create(&self) -> HuakResult<()> {
         if self.path.exists() {
             return Ok(());
@@ -172,6 +172,8 @@ impl Venv {
 
         let name = self.name()?;
         let args = ["-m", "venv", name];
+
+        println!("Creating venv {}", self.path.display());
 
         crate::utils::command::run_command(self.python_alias(), &args, from)?;
 

--- a/src/huak/ops/activate.rs
+++ b/src/huak/ops/activate.rs
@@ -4,9 +4,7 @@ use crate::{
 };
 
 pub fn activate_project_venv(project: &Project) -> HuakResult<()> {
-    let venv = project.venv().as_ref().ok_or_else(|| {
-        HuakError::InternalError("Project's venv is `None`.".to_owned())
-    })?;
+    let venv = project.venv().as_ref().ok_or(HuakError::VenvNotFound)?;
 
     venv.create()?;
 

--- a/src/huak/ops/activate.rs
+++ b/src/huak/ops/activate.rs
@@ -1,10 +1,14 @@
-use crate::{errors::HuakResult, project::Project};
+use crate::{
+    errors::{HuakError, HuakResult},
+    project::Project,
+};
 
 pub fn activate_project_venv(project: &Project) -> HuakResult<()> {
-    let venv = project
-        .venv()
-        .as_ref()
-        .expect("`Project::from` creates venv if it doesn't exists.");
+    let venv = project.venv().as_ref().ok_or_else(|| {
+        HuakError::InternalError("Project's venv is `None`.".to_owned())
+    })?;
+
+    venv.create()?;
 
     println!("Venv activated: {}", venv.path.display());
 


### PR DESCRIPTION
Remove unwrap, create venv on `activate`, print info when we create venv.

Whole venv architecture still bothers me a bit, but I decided not to cram it in this PR ;p