### PR TITLE
Add git initialization to `new` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -299,6 +302,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +403,7 @@ dependencies = [
  "clap",
  "expectrl",
  "fs_extra",
+ "git2",
  "glob",
  "openssl",
  "pyo3",
@@ -499,6 +518,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +546,46 @@ name = "libc"
 version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.14.0+1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ pyo3 = { version = "0.17.1", features = ["abi3"] }
 openssl = { version = "0.10", features = ["vendored"] } # included to build PyPi Wheels (see .github/workflow/README.md)
 expectrl = { version = "0.6.0", features = ["polling"] }
 terminal_size = "0.2.1"
+git2 = "0.15.0"
 
 [dev-dependencies]
 tempfile = "3.0.4"

--- a/src/bin/huak/commands/mod.rs
+++ b/src/bin/huak/commands/mod.rs
@@ -91,6 +91,9 @@ pub enum Commands {
         app: bool,
         /// Path and name of the python package
         path: String,
+        /// Don't initialize VCS in the new project
+        #[arg(long)]
+        no_vcs: bool,
     },
     /// Builds and uploads current project to a registry.
     Publish,
@@ -124,7 +127,12 @@ impl Cli {
             Commands::Init => init::run(),
             Commands::Install { groups, all } => install::run(groups, all),
             Commands::Lint { fix } => lint::run(fix),
-            Commands::New { path, app, lib } => new::run(path, app, lib),
+            Commands::New {
+                path,
+                app,
+                lib,
+                no_vcs,
+            } => new::run(path, app, lib, no_vcs),
             Commands::Publish => publish::run(),
             Commands::Remove { dependency } => remove::run(dependency),
             Commands::Run { command } => run::run(command),

--- a/src/bin/huak/commands/new.rs
+++ b/src/bin/huak/commands/new.rs
@@ -49,28 +49,3 @@ pub fn run(path: String, app: bool, lib: bool, no_vcs: bool) -> CliResult<()> {
 
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use tempfile::tempdir;
-
-    #[test]
-    fn initializes_git() {
-        let directory = tempdir().unwrap().into_path();
-        std::env::set_current_dir(&directory).unwrap();
-        super::run("foo".to_owned(), true, false, false).unwrap();
-        let proj_dir = directory.join("foo");
-        assert!(proj_dir.is_dir());
-        assert!(proj_dir.join(".git").is_dir());
-    }
-
-    #[test]
-    fn does_not_initialize_git() {
-        let directory = tempdir().unwrap().into_path();
-        std::env::set_current_dir(&directory).unwrap();
-        super::run("foo".to_owned(), true, false, true).unwrap();
-        let proj_dir = directory.join("foo");
-        assert!(proj_dir.is_dir());
-        assert!(!proj_dir.join(".git").exists());
-    }
-}

--- a/src/bin/huak/commands/new.rs
+++ b/src/bin/huak/commands/new.rs
@@ -49,3 +49,28 @@ pub fn run(path: String, app: bool, lib: bool, no_vcs: bool) -> CliResult<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    #[test]
+    fn initializes_git() {
+        let directory = tempdir().unwrap().into_path();
+        std::env::set_current_dir(&directory).unwrap();
+        super::run("foo".to_owned(), true, false, false).unwrap();
+        let proj_dir = directory.join("foo");
+        assert!(proj_dir.is_dir());
+        assert!(proj_dir.join(".git").is_dir());
+    }
+
+    #[test]
+    fn does_not_initialize_git() {
+        let directory = tempdir().unwrap().into_path();
+        std::env::set_current_dir(&directory).unwrap();
+        super::run("foo".to_owned(), true, false, true).unwrap();
+        let proj_dir = directory.join("foo");
+        assert!(proj_dir.is_dir());
+        assert!(!proj_dir.join(".git").exists());
+    }
+}

--- a/src/bin/huak/commands/new.rs
+++ b/src/bin/huak/commands/new.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::process::ExitCode;
 
 use crate::errors::{CliError, CliResult};
-use git2::Repository;
 use huak::errors::HuakError;
 use huak::ops;
 use huak::project::Project;
@@ -44,10 +43,8 @@ pub fn run(path: String, app: bool, lib: bool, no_vcs: bool) -> CliResult<()> {
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
     if !no_vcs {
-        // Initialize git repository in the new project
-        Repository::init(&project.root).map_err(|e| {
-            CliError::new(HuakError::GitError(e), ExitCode::FAILURE)
-        })?;
+        ops::new::init_vcs(&project)
+            .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
     }
 
     Ok(())

--- a/src/bin/huak/commands/new.rs
+++ b/src/bin/huak/commands/new.rs
@@ -2,13 +2,14 @@ use std::env;
 use std::process::ExitCode;
 
 use crate::errors::{CliError, CliResult};
+use git2::Repository;
 use huak::errors::HuakError;
 use huak::ops;
 use huak::project::Project;
 use huak::project::ProjectType;
 
 /// Run the `new` command.
-pub fn run(path: String, app: bool, lib: bool) -> CliResult<()> {
+pub fn run(path: String, app: bool, lib: bool, no_vcs: bool) -> CliResult<()> {
     // This command runs from in the context of the current working directory
     let cwd = env::current_dir()?;
 
@@ -41,6 +42,13 @@ pub fn run(path: String, app: bool, lib: bool) -> CliResult<()> {
 
     ops::new::create_project(&project)
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
+
+    if !no_vcs {
+        // Initialize git repository in the new project
+        Repository::init(&project.root).map_err(|e| {
+            CliError::new(HuakError::GitError(e), ExitCode::FAILURE)
+        })?;
+    }
 
     Ok(())
 }

--- a/src/huak/errors.rs
+++ b/src/huak/errors.rs
@@ -82,4 +82,6 @@ pub enum HuakError {
     ExpectrlError(#[from] expectrl::Error),
     #[error("Project name not found.")]
     ProjectNameNotFound,
+    #[error("Git error: {0}.")]
+    GitError(#[from] git2::Error),
 }

--- a/src/huak/ops/new.rs
+++ b/src/huak/ops/new.rs
@@ -1,3 +1,4 @@
+use git2::Repository;
 use std::fs;
 
 use crate::{
@@ -21,6 +22,14 @@ pub fn create_project(project: &Project) -> HuakResult<()> {
     let pyproject_content = pyproject_toml.to_string()?;
     fs::write(&pyproject_path, pyproject_content)?;
 
+    Ok(())
+}
+
+/// Initializes VCS (currently git) in the project
+pub fn init_vcs(project: &Project) -> HuakResult<()> {
+    if let Err(e) = Repository::init(&project.root) {
+        return Err(HuakError::GitError(e));
+    }
     Ok(())
 }
 

--- a/src/huak/ops/new.rs
+++ b/src/huak/ops/new.rs
@@ -119,4 +119,12 @@ def test_version():
         assert_eq!(test_file, expected_test_file);
         assert_eq!(init_file, expected_init_file);
     }
+
+    #[test]
+    fn initialize_git() {
+        let directory = tempdir().unwrap().into_path().join("project");
+        let project = Project::new(directory.clone(), ProjectType::Application);
+        super::init_vcs(&project).unwrap();
+        assert!(directory.join(".git").is_dir());
+    }
 }


### PR DESCRIPTION
Closes #281 
Added initialization of basic git repo to the `new` command. Can be skipped with `--no-vcs`. Adds `git2` dependency, as discussed in the issue.
I considered moving the `init` call to `create_project`, but that didn't feel right.