### PR TITLE
fix: Set `rust-version` to 1.62.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "A Python package manager written in Rust inspired by Cargo."
 repository = "https://github.com/cnpryer/huak.git"
 homepage = "https://github.com/cnpryer/huak.git"
+rust-version = "1.62.0"
 categories = [
     "development-tools"
 ]


### PR DESCRIPTION
Closes #338 

Hi
This PR closes issue #338 , where if your rust version is `<1.62` it would error out(not so nicely). Now, it will error out saying you require minimum version, which is clearer and helps for people trying to install

Btw thanks for package manger. Really looking forward to contributing and helping as I also rely on python for my daily work anad this looks super cool :)  
