### PR TITLE
Bump to 0.0.8-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "huak"
-version = "0.0.7-alpha.3"
+version = "0.0.8-alpha.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huak"
-version = "0.0.7-alpha.3"
+version = "0.0.8-alpha.1"
 edition = "2021"
 license = "MIT"
 description = "A Python package manager written in Rust inspired by Cargo."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "huak"
-version = "0.0.7-alpha.3"
+version = "0.0.8a1"
 description = "A Python package manager written in Rust inspired by Cargo."
 authors = [
     {email = "cnpryer@gmail.com"},


### PR DESCRIPTION
Uses PEP 440 version number for Python package
