### PR TITLE
Refactor venv usage pattern

### DIFF
--- a/src/bin/huak/commands/activate.rs
+++ b/src/bin/huak/commands/activate.rs
@@ -2,7 +2,7 @@ use std::process::ExitCode;
 
 use crate::errors::{CliError, CliResult};
 
-use huak::{ops, project::Project};
+use huak::{env::venv::create_venv, ops, project::Project};
 
 /// Run the `activate` command.
 pub fn run() -> CliResult<()> {
@@ -11,8 +11,10 @@ pub fn run() -> CliResult<()> {
         Ok(p) => p,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
-    ops::activate::activate_project_venv(&project)
+    ops::activate::activate_venv(&venv)
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
     Ok(())
 }

--- a/src/bin/huak/commands/add.rs
+++ b/src/bin/huak/commands/add.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::process::ExitCode;
 
 use crate::errors::{CliError, CliResult};
+use huak::env::venv::create_venv;
 use huak::ops;
 use huak::project::Project;
 
@@ -11,8 +12,10 @@ pub fn run(dependency: String, is_dev: bool) -> CliResult<()> {
         Ok(p) => p,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
-    ops::add::add_project_dependency(&project, &dependency, is_dev)
+    ops::add::add_project_dependency(&project, &venv, &dependency, is_dev)
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
     Ok(())

--- a/src/bin/huak/commands/build.rs
+++ b/src/bin/huak/commands/build.rs
@@ -1,6 +1,6 @@
 use std::{env, process::ExitCode};
 
-use huak::{ops, project::Project};
+use huak::{env::venv::create_venv, ops, project::Project};
 
 use crate::errors::{CliError, CliResult};
 
@@ -11,8 +11,10 @@ pub fn run() -> CliResult<()> {
         Ok(it) => it,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
-    ops::build::build_project(&project)
+    ops::build::build_project(&project, &venv)
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
     Ok(())

--- a/src/bin/huak/commands/fix.rs
+++ b/src/bin/huak/commands/fix.rs
@@ -1,4 +1,5 @@
 use crate::errors::CliError;
+use huak::env::venv::create_venv;
 use huak::ops;
 use huak::project::Project;
 use std::env;
@@ -14,8 +15,10 @@ pub fn run() -> CliResult<()> {
         Ok(p) => p,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
-    if let Err(e) = ops::fix::fix_project(&project) {
+    if let Err(e) = ops::fix::fix_project(&project, &venv) {
         return Err(CliError::new(e, ExitCode::FAILURE));
     };
 

--- a/src/bin/huak/commands/fmt.rs
+++ b/src/bin/huak/commands/fmt.rs
@@ -1,5 +1,5 @@
 use crate::errors::{CliError, CliResult};
-use huak::{ops, project::Project};
+use huak::{env::venv::create_venv, ops, project::Project};
 use std::{env, process::ExitCode};
 
 /// Run the `fmt` command.
@@ -10,8 +10,10 @@ pub fn run(is_check: bool) -> CliResult<()> {
         Ok(p) => p,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
-    ops::fmt::fmt_project(&project, &is_check)
+    ops::fmt::fmt_project(&project, &venv, &is_check)
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
     Ok(())

--- a/src/bin/huak/commands/init.rs
+++ b/src/bin/huak/commands/init.rs
@@ -8,7 +8,6 @@ use huak::project::Project;
 /// Run the `init` command.
 pub fn run() -> CliResult<()> {
     let cwd = env::current_dir()?;
-
     let project = match Project::from(cwd) {
         Ok(p) => p,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),

--- a/src/bin/huak/commands/install.rs
+++ b/src/bin/huak/commands/install.rs
@@ -14,6 +14,7 @@ pub fn run(groups: Option<Vec<String>>, all: bool) -> CliResult<()> {
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
 
+    // TODO: Create .venv anyway?
     let venv = Venv::from_path(project.root())
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 

--- a/src/bin/huak/commands/lint.rs
+++ b/src/bin/huak/commands/lint.rs
@@ -1,4 +1,5 @@
 use crate::errors::CliError;
+use huak::env::venv::create_venv;
 use huak::ops;
 use huak::project::Project;
 use std::env;
@@ -14,10 +15,12 @@ pub fn run(fix: bool) -> CliResult<()> {
         Ok(p) => p,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
     let res = match fix {
-        true => ops::fix::fix_project(&project),
-        false => ops::lint::lint_project(&project),
+        true => ops::fix::fix_project(&project, &venv),
+        false => ops::lint::lint_project(&project, &venv),
     };
 
     res.map_err(|e| CliError::new(e, ExitCode::FAILURE))?;

--- a/src/bin/huak/commands/remove.rs
+++ b/src/bin/huak/commands/remove.rs
@@ -2,8 +2,7 @@ use std::env;
 use std::process::ExitCode;
 
 use crate::errors::{CliError, CliResult};
-use huak::env::venv::Venv;
-use huak::errors::HuakError;
+use huak::env::venv::create_venv;
 use huak::ops;
 use huak::project::Project;
 
@@ -15,11 +14,8 @@ pub fn run(dependency: String) -> CliResult<()> {
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
 
-    let venv = match Venv::from_path(project.root()) {
-        Ok(it) => it,
-        Err(HuakError::VenvNotFound) => Venv::new(project.root().join(".venv")),
-        Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
-    };
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
     ops::remove::remove_project_dependency(&venv, &project, &dependency)
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;

--- a/src/bin/huak/commands/run.rs
+++ b/src/bin/huak/commands/run.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::process::ExitCode;
 
 use crate::errors::{CliError, CliResult};
+use huak::env::venv::create_venv;
 use huak::ops;
 use huak::project::Project;
 
@@ -10,8 +11,10 @@ pub fn run(command: Vec<String>) -> CliResult<()> {
     let cwd = env::current_dir()?;
     let project =
         Project::from(cwd).map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
-    ops::run::run_command(&project, &command)
+    ops::run::run_command(&venv, &command)
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
     Ok(())

--- a/src/bin/huak/commands/test.rs
+++ b/src/bin/huak/commands/test.rs
@@ -1,5 +1,6 @@
 use crate::errors::CliError;
 use crate::errors::CliResult;
+use huak::env::venv::create_venv;
 use huak::ops;
 use huak::project::Project;
 use std::env;
@@ -14,8 +15,10 @@ pub fn run() -> CliResult<()> {
         Ok(p) => p,
         Err(e) => return Err(CliError::new(e, ExitCode::FAILURE)),
     };
+    let venv = create_venv(project.root())
+        .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
-    ops::test::test_project(&project)
+    ops::test::test_project(&project, &venv)
         .map_err(|e| CliError::new(e, ExitCode::FAILURE))?;
 
     Ok(())

--- a/src/huak/env/venv.rs
+++ b/src/huak/env/venv.rs
@@ -311,6 +311,21 @@ impl Venv {
     }
 }
 
+// Helper function to create a venv from a path. If it already exists, initialize
+// and return the Venv. If it doesn't then create a .venv at the path given.
+pub fn create_venv(dirpath: &Path) -> HuakResult<Venv> {
+    let venv = match Venv::from_path(dirpath) {
+        Ok(it) => it,
+        Err(HuakError::VenvNotFound) => Venv::new(dirpath.join(".venv")),
+        Err(e) => return Err(e),
+    };
+
+    // Attempt to create the venv. If it already exists nothing will happen.
+    venv.create()?;
+
+    Ok(venv)
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;

--- a/src/huak/ops/activate.rs
+++ b/src/huak/ops/activate.rs
@@ -1,9 +1,6 @@
-use crate::{env::venv::Venv, errors::HuakResult, project::Project};
+use crate::{env::venv::Venv, errors::HuakResult};
 
-pub fn activate_project_venv(project: &Project) -> HuakResult<()> {
-    let venv = &Venv::from_path(project.root())?;
-
-    venv.create()?;
+pub fn activate_venv(venv: &Venv) -> HuakResult<()> {
     venv.activate()?;
 
     Ok(())
@@ -23,23 +20,11 @@ mod tests {
     // TODO
     fn venv_can_be_activated() {
         let project = create_mock_project_full().unwrap();
+        let venv = &Venv::from_path(project.root()).unwrap();
 
         assert!(std::env::var(HUAK_VENV_ENV_VAR).is_err());
 
-        let result = activate_project_venv(&project);
+        let result = activate_venv(&venv);
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn venv_cant_be_activated() {
-        let project = create_mock_project_full().unwrap();
-
-        std::env::set_var(HUAK_VENV_ENV_VAR, "1");
-        assert!(std::env::var(HUAK_VENV_ENV_VAR).is_ok());
-
-        let result = activate_project_venv(&project);
-        assert!(result.is_err());
-
-        std::env::remove_var(HUAK_VENV_ENV_VAR);
     }
 }

--- a/src/huak/ops/build.rs
+++ b/src/huak/ops/build.rs
@@ -5,13 +5,7 @@ use crate::{
 
 const MODULE: &str = "build";
 
-pub fn build_project(project: &Project) -> Result<(), HuakError> {
-    let venv = match Venv::from_path(project.root()) {
-        Ok(it) => it,
-        Err(HuakError::VenvNotFound) => Venv::new(project.root().join(".venv")),
-        Err(_) => return Err(HuakError::VenvNotFound),
-    };
-
+pub fn build_project(project: &Project, venv: &Venv) -> Result<(), HuakError> {
     let package = PythonPackage::from("build")?;
 
     venv.install_package(&package)
@@ -34,7 +28,9 @@ mod tests {
     #[test]
     fn build() {
         let project = create_mock_project_full().unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        let venv = Venv::new(cwd.join(".venv"));
 
-        build_project(&project).unwrap();
+        build_project(&project, &venv).unwrap();
     }
 }

--- a/src/huak/ops/fix.rs
+++ b/src/huak/ops/fix.rs
@@ -1,18 +1,9 @@
-use crate::{
-    env::venv::Venv,
-    errors::{HuakError, HuakResult},
-    project::Project,
-};
+use crate::{env::venv::Venv, errors::HuakResult, project::Project};
 
 const MODULE: &str = "ruff";
 
 /// Fixes the lint error the project from its root.
-pub fn fix_project(project: &Project) -> HuakResult<()> {
-    let venv = match Venv::from_path(project.root()) {
-        Ok(it) => it,
-        Err(HuakError::VenvNotFound) => Venv::new(project.root().join(".venv")),
-        Err(_) => return Err(HuakError::VenvNotFound),
-    };
+pub fn fix_project(project: &Project, venv: &Venv) -> HuakResult<()> {
     let args = [".", "--fix", "--extend-exclude", venv.name()?];
 
     venv.exec_module(MODULE, &args, project.root())
@@ -51,7 +42,7 @@ def fn():
 "#;
 
         fs::write(&lint_fix_filepath, pre_fix_str).unwrap();
-        fix_project(&project).unwrap();
+        fix_project(&project, &venv).unwrap();
         let post_fix_str = fs::read_to_string(&lint_fix_filepath).unwrap();
 
         assert_eq!(post_fix_str, expected);

--- a/src/huak/ops/fmt.rs
+++ b/src/huak/ops/fmt.rs
@@ -5,14 +5,9 @@ const MODULE: &str = "black";
 /// Format Python code from the `Project`'s root.
 pub fn fmt_project(
     project: &Project,
+    venv: &Venv,
     is_check: &bool,
 ) -> Result<(), HuakError> {
-    let venv = match Venv::from_path(project.root()) {
-        Ok(it) => it,
-        Err(HuakError::VenvNotFound) => Venv::new(project.root().join(".venv")),
-        Err(_) => return Err(HuakError::VenvNotFound),
-    };
-
     match is_check {
         true => venv.exec_module(
             MODULE,
@@ -39,7 +34,7 @@ mod tests {
     fn fmt() {
         let project = create_mock_project_full().unwrap();
         let cwd = std::env::current_dir().unwrap();
-        let venv = &Venv::new(cwd.join(".venv"));
+        let venv = Venv::new(cwd.join(".venv"));
 
         venv.exec_module("pip", &["install", MODULE], project.root())
             .unwrap();
@@ -50,7 +45,7 @@ mod tests {
 def fn( ):
     pass"#;
         fs::write(&fmt_filepath, pre_fmt_str).unwrap();
-        fmt_project(&project, &false).unwrap();
+        fmt_project(&project, &venv, &false).unwrap();
         let post_fmt_str = fs::read_to_string(&fmt_filepath).unwrap();
 
         assert_ne!(pre_fmt_str, post_fmt_str);

--- a/src/huak/ops/lint.rs
+++ b/src/huak/ops/lint.rs
@@ -3,8 +3,7 @@ use crate::{env::venv::Venv, errors::HuakResult, project::Project};
 const MODULE: &str = "ruff";
 
 /// Lint the project from its root.
-pub fn lint_project(project: &Project) -> HuakResult<()> {
-    let venv = &Venv::from_path(project.root())?;
+pub fn lint_project(project: &Project, venv: &Venv) -> HuakResult<()> {
     let args = [".", "--extend-exclude", venv.name()?];
 
     venv.exec_module(MODULE, &args, project.root())

--- a/src/huak/ops/run.rs
+++ b/src/huak/ops/run.rs
@@ -1,7 +1,6 @@
-use crate::{env::venv::Venv, errors::HuakResult, project::Project};
+use crate::{env::venv::Venv, errors::HuakResult};
 
-pub fn run_command(project: &Project, command: &[String]) -> HuakResult<()> {
-    let venv = &Venv::from_path(project.root())?;
+pub fn run_command(venv: &Venv, command: &[String]) -> HuakResult<()> {
     venv.exec_command(&command.join(" "))
 }
 
@@ -22,7 +21,7 @@ mod tests {
             .split_whitespace()
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
-        run_command(&project, &command).unwrap();
+        run_command(&venv, &command).unwrap();
 
         let data = std::fs::read_to_string("test_req.txt").unwrap();
         assert!(data.contains("black"));

--- a/src/huak/ops/test.rs
+++ b/src/huak/ops/test.rs
@@ -3,9 +3,8 @@ use crate::{env::venv::Venv, errors::HuakResult, project::Project};
 const MODULE: &str = "pytest";
 
 /// Test a project using `pytest`.
-pub fn test_project(project: &Project) -> HuakResult<()> {
+pub fn test_project(project: &Project, venv: &Venv) -> HuakResult<()> {
     let args = [];
-    let venv = &Venv::from_path(project.root())?;
 
     // TODO: not sure if the PyTestError was something you wanted to override
     // the internal HuakError, so leaving as comment for now.


### PR DESCRIPTION
More Venv usage refactoring. Instead of coupling together usage of Venv inside most Project manipulation, the operations expect a Venv to use *alongside* any given Project.

This should help in the future when Venv specifically isn't used (if its not too much of a PEP deviance).