### PR TITLE
Remove cargo install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ Install with `pip`:
 
 `❯ pip install huak --pre`
 
-Install with `cargo`:
-
-`❯ cargo install huak --version` [![crates.io](https://img.shields.io/crates/v/huak.svg?label="")](https://crates.io/crates/huak)
-
 Around 0.1.0 you'll be able to install `huak` using `brew`. More distribution plans will be finalized closer to 0.1.0.
 
 ```console

--- a/src/huak/lib.rs
+++ b/src/huak/lib.rs
@@ -24,7 +24,7 @@
 //!
 //!During the [Alpha phase](https://github.com/cnpryer/huak/milestones) you'll need to explicitly install the latest pre-release available.
 //!
-//!`❯ cargo install huak --version` [![crates.io](https://img.shields.io/crates/v/huak.svg?label="")](https://crates.io/crates/huak)
+//!`❯ pip install huak --pre
 //!
 //!Around 0.1.0 you'll be able to install `huak` using `brew` or `pip`. Distribution plans will be finalized closer to 0.1.0.
 //!


### PR DESCRIPTION
Huak cannot be published to crates.io until pep440-rs is published.

https://github.com/konstin/pep440-rs/issues/4