### PR TITLE
Don't filter out python paths missing a version

### DIFF
--- a/src/huak/lib.rs
+++ b/src/huak/lib.rs
@@ -1027,7 +1027,7 @@ pub struct CleanOptions {
 /// Get an iterator over available Python interpreter paths parsed from PATH.
 /// Inspired by brettcannon/python-launcher
 pub fn find_python_interpreter_paths(
-) -> impl Iterator<Item = (PathBuf, Version)> {
+) -> impl Iterator<Item = (PathBuf, Option<Version>)> {
     let paths =
         fs::flatten_directories(sys::env_path_values().unwrap_or(Vec::new()));
     all_python_interpreters_in_paths(paths)
@@ -1035,11 +1035,10 @@ pub fn find_python_interpreter_paths(
 
 fn all_python_interpreters_in_paths(
     paths: impl IntoIterator<Item = PathBuf>,
-) -> impl Iterator<Item = (PathBuf, Version)> {
+) -> impl Iterator<Item = (PathBuf, Option<Version>)> {
     paths
         .into_iter()
         .map(|item| (item.clone(), python_version_from_path(item.as_path())))
-        .filter_map(|(path, version)| version.map(|v| (path, v)))
 }
 
 /// Parse a Python interpreter's version from its path if one exists.

--- a/src/huak/lib.rs
+++ b/src/huak/lib.rs
@@ -1329,6 +1329,7 @@ dev = [
         assert_eq!(package.version(), None); // TODO
     }
 
+    #[cfg(unix)]
     #[test]
     fn python_search() {
         let dir = tempdir().unwrap().into_path();
@@ -1338,5 +1339,17 @@ dev = [
         let mut interpreter_paths = find_python_interpreter_paths();
 
         assert_eq!(interpreter_paths.next().unwrap().0, dir.join("python3.11"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn python_search() {
+        let dir = tempdir().unwrap().into_path();
+        std::fs::write(dir.join("python.exe"), "").unwrap();
+        let path_vals = vec![dir.to_str().unwrap().to_string()];
+        std::env::set_var("PATH", path_vals.join(":"));
+        let mut interpreter_paths = find_python_interpreter_paths();
+
+        assert_eq!(interpreter_paths.next().unwrap().0, dir.join("python.exe"));
     }
 }

--- a/src/huak/lib.rs
+++ b/src/huak/lib.rs
@@ -1026,8 +1026,7 @@ pub struct CleanOptions {
 
 /// Get an iterator over available Python interpreter paths parsed from PATH.
 /// Inspired by brettcannon/python-launcher
-pub fn find_python_interpreter_paths(
-) -> impl Iterator<Item = (PathBuf, Option<Version>)> {
+pub fn python_paths() -> impl Iterator<Item = (PathBuf, Option<Version>)> {
     let paths =
         fs::flatten_directories(sys::env_path_values().unwrap_or(Vec::new()));
     all_python_interpreters_in_paths(paths)
@@ -1329,6 +1328,13 @@ dev = [
         assert_eq!(package.version(), None); // TODO
     }
 
+    #[test]
+    fn find_python() {
+        let path = python_paths().next().unwrap().0;
+
+        assert!(path.exists());
+    }
+
     #[cfg(unix)]
     #[test]
     fn python_search() {
@@ -1336,7 +1342,7 @@ dev = [
         std::fs::write(dir.join("python3.11"), "").unwrap();
         let path_vals = vec![dir.to_str().unwrap().to_string()];
         std::env::set_var("PATH", path_vals.join(":"));
-        let mut interpreter_paths = find_python_interpreter_paths();
+        let mut interpreter_paths = python_paths();
 
         assert_eq!(interpreter_paths.next().unwrap().0, dir.join("python3.11"));
     }
@@ -1348,7 +1354,7 @@ dev = [
         std::fs::write(dir.join("python.exe"), "").unwrap();
         let path_vals = vec![dir.to_str().unwrap().to_string()];
         std::env::set_var("PATH", path_vals.join(":"));
-        let mut interpreter_paths = find_python_interpreter_paths();
+        let mut interpreter_paths = python_paths();
 
         assert_eq!(interpreter_paths.next().unwrap().0, dir.join("python.exe"));
     }

--- a/src/huak/ops.rs
+++ b/src/huak/ops.rs
@@ -673,6 +673,7 @@ fn create_virtual_environment(
     config: &OperationConfig,
     terminal: &mut Terminal,
 ) -> HuakResult<()> {
+    // Use the first path found.
     let python_path = match find_python_interpreter_paths().next() {
         Some(it) => it.0,
         None => return Err(Error::PythonNotFoundError),

--- a/src/huak/ops.rs
+++ b/src/huak/ops.rs
@@ -5,9 +5,9 @@ use crate::{
     default_main_file_contents, default_test_file_contents,
     default_virtual_environment_name,
     error::HuakResult,
-    find_python_interpreter_paths, find_venv_root,
+    find_venv_root,
     fs::{self, find_root_file_bottom_up},
-    git, package_iter,
+    git, package_iter, python_paths,
     sys::{self, shell_name, Terminal, TerminalOptions},
     to_importable_package_name, to_package_cononical_name, BuildOptions,
     CleanOptions, Error, FormatOptions, InstallerOptions, LintOptions, Package,
@@ -674,7 +674,7 @@ fn create_virtual_environment(
     terminal: &mut Terminal,
 ) -> HuakResult<()> {
     // Use the first path found.
-    let python_path = match find_python_interpreter_paths().next() {
+    let python_path = match python_paths().next() {
         Some(it) => it.0,
         None => return Err(Error::PythonNotFoundError),
     };

--- a/src/huak/ops.rs
+++ b/src/huak/ops.rs
@@ -3,12 +3,12 @@
 use crate::{
     default_entrypoint_string, default_init_file_contents,
     default_main_file_contents, default_test_file_contents,
-    default_virtual_environment_name,
+    default_virtual_environment_name, env_path_values,
     error::HuakResult,
     find_venv_root,
     fs::{self, find_root_file_bottom_up},
     git, package_iter, python_paths,
-    sys::{self, shell_name, Terminal, TerminalOptions},
+    sys::{shell_name, Terminal, TerminalOptions},
     to_importable_package_name, to_package_cononical_name, BuildOptions,
     CleanOptions, Error, FormatOptions, InstallerOptions, LintOptions, Package,
     Project, PublishOptions, PyProjectToml, TestOptions, VirtualEnvironment,
@@ -586,7 +586,7 @@ fn make_venv_command(
     cmd: &mut Command,
     venv: &VirtualEnvironment,
 ) -> HuakResult<()> {
-    let mut paths = match sys::env_path_values() {
+    let mut paths = match env_path_values() {
         Some(it) => it,
         None => {
             return Err(Error::InternalError(

--- a/src/huak/sys.rs
+++ b/src/huak/sys.rs
@@ -3,44 +3,11 @@ use crate::Error;
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
-use std::{ffi::OsString, path::PathBuf};
 use termcolor::{self, Color, ColorSpec, StandardStream, WriteColor};
 use termcolor::{
     Color::{Cyan, Green, Red, Yellow},
     ColorChoice,
 };
-
-const VIRTUAL_ENV_ENV_VAR: &str = "VIRUTAL_ENV";
-const CONDA_ENV_ENV_VAR: &str = "CONDA_PREFIX";
-
-/// Get a vector of paths from the system PATH environment variable.
-pub fn env_path_values() -> Option<Vec<PathBuf>> {
-    if let Some(val) = env_path_string() {
-        return Some(std::env::split_paths(&val).collect());
-    }
-    None
-}
-
-/// Get the OsString value of the enrionment variable PATH.
-pub fn env_path_string() -> Option<OsString> {
-    std::env::var_os("PATH")
-}
-
-/// Get the VIRTUAL_ENV environment path if it exists.
-pub fn active_virtual_env_path() -> Option<PathBuf> {
-    if let Ok(path) = std::env::var(VIRTUAL_ENV_ENV_VAR) {
-        return Some(PathBuf::from(path));
-    }
-    None
-}
-
-/// Get the CONDA_PREFIX environment path if it exists.
-pub fn active_conda_env_path() -> Option<PathBuf> {
-    if let Ok(path) = std::env::var(CONDA_ENV_ENV_VAR) {
-        return Some(PathBuf::from(path));
-    }
-    None
-}
 
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub enum Verbosity {


### PR DESCRIPTION
On windows the original path search was too restrictive since python.exe might be the only interpreter available.

\+ small refactor