### PR TITLE
Improving `huak run` and `huak activate`

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -39,8 +39,8 @@ To create a new project use the `new` command.
 
 Initializing an existing project adds a `pyproject.toml` to the current directory. Bootstrapping the project with the `new` command creates a Python project with the following structure:
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ tree .
 .
 ├── pyproject.toml
@@ -59,8 +59,8 @@ Note that without `--no-vcs` `huak` generates a `git`-initialized project.
 
 Use `huak` to add dependencies to your Python project.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak add xlcsv
 ```
 
@@ -68,8 +68,8 @@ my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0
 
 Currently `huak` uses `pip` under the hood for package installation. You can pass additional arguments onto `pip`. Any arguments after `--` are handed off to `pip install`.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak add torch torchvision torchaudio -- --extra-index-url https://download.pytorch.org/whl/cu117
 ```
 
@@ -81,8 +81,8 @@ You can also assign dependencies to a group using `--group`.
 
 Use the `install` command to install the project's dependencies.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak install
 ```
 
@@ -90,8 +90,8 @@ my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0
 
 To install all dependencies (including optional dependencies) use the group name "all".
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak install --groups all
 ```
 
@@ -101,11 +101,11 @@ If you already have an optional dependency group named "all" then `--groups` wil
 
 `huak install` would trigger a standard `pip install` on your group's packages. So without PEP 508 you won't install the pytorch.org packages as demonstrated with `huak add` earlier. To do this you could pass the same options given to `huak add`. Use a group to isolate these options to those specific dependencies.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak add torch torchvision torchaudio --group torch -- --extra-index-url https://download.pytorch.org/whl/cu117
 
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak install --groups torch -- --extra-index-url https://download.pytorch.org/whl/cu117
 ```
 
@@ -115,8 +115,8 @@ In the future `huak` will manage translating installer options to PEP 508 string
 
 To remove a dependency from the project use the `remove` command.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak remove xlcsv
 ```
 
@@ -128,8 +128,8 @@ Huak ships commands allowing you to format your python code, lint it, and test i
 
 Use the `fmt` command to format your Python project's code.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak fmt
 ```
 
@@ -143,8 +143,8 @@ Use `--check` if all you want to do is verify your code is already formatted. No
 
 Use the `lint` command to lint your Python project's code.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 took 2s 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 took 2s 
 ❯ huak lint
 ```
 
@@ -159,8 +159,8 @@ The `--fix` flag can be used to address any auto-fixable issues.
 
 `huak` also uses `mypy` for type-checking. To disable this behavior use `--no-types`.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 took 2s 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 took 2s 
 ❯ huak lint --no-types
 ```
 
@@ -170,8 +170,8 @@ Currently, since `ruff` is the default tool used by `huak lint`, passing additio
 
 Use the `test` command to test your project.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0
 ❯ huak test
 ```
 
@@ -179,10 +179,13 @@ my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0
 
 You can use `huak` to run a command within the Python environment your project uses.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak run which python
 /Users/chrispryer/github/my-project/.venv/bin/python
+
+❯ huak run python -c 'import sys; print("path:", sys.executable)'
+path: /Users/chrispryer/github/my-project/.venv/bin/python
 ```
 
 ## Distribute your project
@@ -191,11 +194,11 @@ my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0
 
 If you're building a Python package you'd like to share, use `huak build` and `huak publish` to build and publish the project to [PyPI](https://pypi.org).
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak build
 
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak publish
 ```
 
@@ -203,8 +206,8 @@ my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0
 
 Use `huak clean` to clean out the dist/ directory.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 took 26s 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 took 26s 
 ❯ huak clean
 ```
 
@@ -216,8 +219,8 @@ Use `huak config` commands to configure `huak`.
 
 With `huak config completion` you can setup shell completion for `huak`.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak config completion -h
 Generates a shell completion script for supported shells. See the help menu for more information on supported shells
 
@@ -234,8 +237,8 @@ Options:
 
 Any bugs or suggestions can be submitted as issues [here](https://github.com/cnpryer/huak/issues/new). All feedback is welcome and greatly appreciated ❤️.
 
-```
-my-project on  master [?] is 📦 v0.0.1 via 🐍 v3.11.0 
+```zsh
+my-project on  master 📦 v0.0.1 via 🐍 v3.11.0 
 ❯ huak --version
 huak 0.0.10-alpha.6
 ```

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -14,7 +14,7 @@
 
 Use `pip` to install `huak` from [PyPI](https://pypi.org).
 
-```
+```zsh
 ~/github 
 ❯ pip install huak
 ```
@@ -23,14 +23,14 @@ Use `pip` to install `huak` from [PyPI](https://pypi.org).
 
 To create a new project use the `new` command.
 
-```
+```zsh
 ~/github took 2s 
 ❯ huak new my-project
 ```
 
 ### Or initialize an existing project
 
-```
+```zsh
 ~/github/existing-project 
 ❯ huak init
 ```

--- a/src/bin/huak/cli.rs
+++ b/src/bin/huak/cli.rs
@@ -415,7 +415,7 @@ fn run(
     command: Vec<String>,
     operation_config: OperationConfig,
 ) -> HuakResult<()> {
-    ops::run_command_str(&command.join(" "), &operation_config)
+    ops::run_command(&command, &operation_config)
 }
 
 fn test(operation_config: OperationConfig) -> HuakResult<()> {

--- a/src/huak/ops.rs
+++ b/src/huak/ops.rs
@@ -1325,13 +1325,12 @@ if __name__ == "__main__":
         venv.uninstall_packages(&["black"], None, &mut terminal)
             .unwrap();
         let venv_had_package = venv.contains_module("black").unwrap();
-
+        #[cfg(unix)]
+        let arg = "import sys;print(\"path:\",sys.executable)".to_string();
+        #[cfg(windows)]
+        let arg = "\"import sys;print('path:',sys.executable)\"".to_string();
         run_command(
-            &vec![
-                "python".to_string(),
-                "-c".to_string(),
-                "import sys;print(\"path:\",sys.executable)".to_string(),
-            ],
+            &vec!["python".to_string(), "-c".to_string(), arg],
             &config,
         )
         .unwrap();

--- a/src/huak/ops.rs
+++ b/src/huak/ops.rs
@@ -508,9 +508,16 @@ pub fn run_command(
     };
     let venv = resolve_venv(config, &mut terminal)?;
     make_venv_command(&mut cmd, &venv)?;
+    #[cfg(unix)]
     let command_string = command
         .iter()
         .map(|item| format!("'{item}'"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    #[cfg(windows)]
+    let command_string = command
+        .iter()
+        .map(|item| item.to_owned())
         .collect::<Vec<_>>()
         .join(" ");
     cmd.args([flag, &command_string])


### PR DESCRIPTION
Closes #464
Closes #486 

Leaving this as a draft PR to tinker with the `run` and `activate` commands. 

De-prioritizing for now. Can't run 
```zsh
❯ huak run python -c 'import sys;print(sys.executable)'
```
because of how `zsh` will parse the command. A workaround would be to run

```zsh
❯ huak run python -c '"import sys;print(sys.executable)"'
```

As for the `activate` command, I don't personally use it much, but if I do `venv` is already distributed with a bunch to simplify this to two commands (one for windows and one for unix). It's not ideal for newer Python users, but my use case is limited. So I'll return to this when I have more time.