### PR TITLE
Adding assert to test of function for python use command: 597

### DIFF
--- a/crates/huak_ops/src/ops/python.rs
+++ b/crates/huak_ops/src/ops/python.rs
@@ -60,6 +60,7 @@ mod tests {
         let cwd = root;
         let config = test_config(root, cwd, Verbosity::Quiet);
 
-        use_python(&version.to_string(), &config).unwrap();
+        let result = use_python(&version.to_string(), &config).unwrap();
+        assert_eq!(result, ());
     }
 }


### PR DESCRIPTION
Based on the ticket, the test on the function for the python use command needs an assert statement.  I added the assert to check that function returns `()`.  I assume this is what is needed rather than changing the function's return value.  I say because the terminal method that is called return a `HuakResult<()>` just as the `use_python` function does.

If I misunderstood the ticket, let me know and I'll correct the pr.