### PR TITLE
Refactor to use pep_440rs crate for python interpreter definition - 599

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "human-panic",
  "insta-cmd",
  "openssl",
+ "pep440_rs",
  "tempfile",
  "termcolor",
  "thiserror",

--- a/crates/huak_cli/Cargo.toml
+++ b/crates/huak_cli/Cargo.toml
@@ -17,6 +17,7 @@ clap_complete = "4.3.2"
 colored = "2.0.4"
 huak_ops = { path = "../huak_ops"}
 human-panic = "1.1.3"
+pep440_rs = "0.3.11"
 # included to build PyPi Wheels (see .github/workflow/README.md)
 openssl = { version = "0.10.52", features = ["vendored"], optional = true }
 termcolor = { workspace = true }

--- a/crates/huak_cli/src/cli.rs
+++ b/crates/huak_cli/src/cli.rs
@@ -8,8 +8,9 @@ use huak_ops::{
         LintOptions, PublishOptions, RemoveOptions, TestOptions, UpdateOptions,
     },
     Config, Error as HuakError, HuakResult, InstallOptions, TerminalOptions,
-    Verbosity, Version, WorkspaceOptions,
+    Verbosity, WorkspaceOptions,
 };
+use pep440_rs::Version as VersionPEP440;
 use std::{path::PathBuf, process::ExitCode, str::FromStr};
 use termcolor::ColorChoice;
 
@@ -499,19 +500,19 @@ impl ToString for Dependency {
 }
 
 #[derive(Debug, Clone)]
-pub struct PythonVersion(String);
+pub struct PythonVersion(VersionPEP440);
 
 impl FromStr for PythonVersion {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let version = Version::from_str(s).map_err(|_| {
+        let version = VersionPEP440::from_str(s).map_err(|_| {
             Error::new(
                 HuakError::InternalError("failed to parse version".to_string()),
                 ExitCode::FAILURE,
             )
         })?;
 
-        Ok(Self(version.to_string()))
+        Ok(Self(version))
     }
 }

--- a/crates/huak_ops/src/lib.rs
+++ b/crates/huak_ops/src/lib.rs
@@ -66,7 +66,6 @@ pub use fs::home_dir;
 pub use python_environment::InstallOptions;
 use python_environment::PythonEnvironment;
 pub use sys::{SubprocessError, TerminalOptions, Verbosity};
-pub use version::Version;
 pub use workspace::{find_package_root, WorkspaceOptions};
 
 #[cfg(test)]

--- a/crates/huak_ops/src/ops/python.rs
+++ b/crates/huak_ops/src/ops/python.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     Config, Error, HuakResult,
 };
+use pep440_rs::Version as VersionPEP440;
 use std::process::Command;
 use termcolor::Color;
 
@@ -22,7 +23,7 @@ pub fn list_python(config: &Config) -> HuakResult<()> {
     Ok(())
 }
 
-pub fn use_python(version: &str, config: &Config) -> HuakResult<()> {
+pub fn use_python(version: &VersionPEP440, config: &Config) -> HuakResult<()> {
     let interpreters = Environment::resolve_python_interpreters();
 
     // Get a path to an interpreter based on the version provided, excluding any activated Python environment.
@@ -34,7 +35,7 @@ pub fn use_python(version: &str, config: &Config) -> HuakResult<()> {
                 py.path().parent() == Some(&venv_executables_dir_path(it))
             })
         })
-        .find(|py| py.version().to_string() == version)
+        .find(|py| py.version() == version)
         .map(|py| py.path())
     {
         Some(it) => it,
@@ -75,6 +76,6 @@ mod tests {
         let cwd = root;
         let config = test_config(root, cwd, Verbosity::Quiet);
 
-        use_python(&version.to_string(), &config).unwrap();
+        use_python(version, &config).unwrap();
     }
 }


### PR DESCRIPTION
# Python Version using pep_440rs

This pr converts to using the crate pep_440rs for handling the python version
for python interpreter definition.  Te crate pep_440rs handles the different
cases of version definitions, such as epochs and dev.  Along with parsing the different
cases, the crate handles comparison between two version definitions.

This refactor passes the version as an instance of the `pep_440rs::Version` rather
than a string representation of the version definition.
