### PR TITLE
Don't panic from invalid version specifiers

### DIFF
--- a/crates/huak_ops/src/ops/install.rs
+++ b/crates/huak_ops/src/ops/install.rs
@@ -70,7 +70,6 @@ mod tests {
         package::Package,
         test_resources_dir_path, Verbosity,
     };
-    use std::str::FromStr;
     use tempfile::tempdir;
 
     #[test]


### PR DESCRIPTION
Ref #712

Removes `FromStr`. I'd like to use it for this, but I'll include this in some of my next refactor work.