### PR TITLE
Use .exe extension on windows during toolchain installation

### DIFF
--- a/crates/huak-package-manager/src/ops/toolchain.rs
+++ b/crates/huak-package-manager/src/ops/toolchain.rs
@@ -247,7 +247,7 @@ fn install(path: PathBuf, channel: Channel, config: &Config) -> HuakResult<()> {
     terminal.run_command(&mut cmd)?;
 
     let venv = from.join(name);
-    let path = venv.join(python_bin_name()).join("python");
+    let path = maybe_exe(venv.join(python_bin_name()).join("python"));
 
     terminal.print_custom(
         "Success",


### PR DESCRIPTION
cc #844 

This doesn't resolve 844, but it is necessary for that specific line. In order to resolve 844 I'll research Python builds a little more (including any special python standalone builds logic). Ideally it's just some simple resolution like if not here, try here, then here. 