### PR TITLE
Resolve toolchain with 'python' subcommand

### DIFF
--- a/crates/huak-package-manager/src/ops/python.rs
+++ b/crates/huak-package-manager/src/ops/python.rs
@@ -7,7 +7,8 @@ use huak_python_manager::{
     install_with_target, release_options_from_requested_version, resolve_release, RequestedVersion,
     Strategy,
 };
-use std::process::Command;
+use huak_toolchain::Channel;
+use std::{process::Command, str::FromStr};
 use termcolor::Color;
 
 pub fn list_python(config: &Config) -> HuakResult<()> {
@@ -25,21 +26,26 @@ pub fn list_python(config: &Config) -> HuakResult<()> {
 }
 
 pub fn use_python(version: &RequestedVersion, config: &Config) -> HuakResult<()> {
-    let interpreters = Environment::resolve_python_interpreters();
+    let ws = config.workspace();
 
-    // TODO(cnpryer): Re-export `Interpreter` as public
-    // Get a path to an interpreter based on the version provided, excluding any activated Python environment.
-    #[allow(clippy::redundant_closure_for_method_calls)]
-    let Some(path) = interpreters
-        .interpreters()
-        .iter()
-        .filter(|py| {
-            !active_python_env_path().map_or(false, |it| {
-                py.path().parent() == Some(&venv_executables_dir_path(it))
-            })
-        })
-        .find(|py| version.matches_version(py.version()))
-        .map(|py| py.path())
+    let Some(path) = ws
+        .resolve_local_toolchain(Some(&Channel::from_str(&version.to_string())?))
+        .ok()
+        .map(|it| it.tool("python").path)
+        .or(
+            // TODO(cnpryer): Re-export `Interpreter` as public
+            // Get a path to an interpreter based on the version provided, excluding any activated Python environment.
+            Environment::resolve_python_interpreters()
+                .interpreters()
+                .iter()
+                .filter(|py| {
+                    !active_python_env_path().map_or(false, |it| {
+                        py.path().parent() == Some(&venv_executables_dir_path(it))
+                    })
+                })
+                .find(|py| version.matches_version(py.version()))
+                .map(|py| py.path().clone()), // TODO(cnpryer): Perf
+        )
     else {
         return Err(Error::PythonNotFound);
     };


### PR DESCRIPTION
```
huak on  toolchain-python [$] is 📦 v0.0.20a1 via 🐍 v3.11.6 via 🦀 v1.75.0-nightly 
❯ cargo run --bin huak python use 3.11 

huak on  master [$!] is 📦 v0.0.20a1 via 🐍 v3.11.6 via 🦀 v1.75.0-nightly took 14s 
❯ cat ./.venv/pyvenv.cfg               
home = /Users/chrispryer/.huak/toolchains/3.11/bin
include-system-site-packages = false
version = 3.11.6
executable = /Users/chrispryer/.huak/toolchains/3.11/downloads/python/install/bin/python3.11
command = /Users/chrispryer/.huak/toolchains/3.11/bin/python -m venv /Users/chrispryer/github/huak/.venv
```