### PR TITLE
Use --locked for CI's cargo install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-python@v1
       # We install instead of just build for insta-cmd TODO(cnpryer)
       - name: Install huak
-        run: cargo install --path crates/huak-cli
+        run: cargo install --path crates/huak-cli --locked
       - name: Test
         run: cargo test --workspace --all-features
 


### PR DESCRIPTION
Should avoid CI failures like #882 (multiple dep versions)