### PR TITLE
Add freeze command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror",
+ "toml 0.8.12",
  "url",
 ]
 
@@ -600,7 +601,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror",
- "toml 0.8.8",
+ "toml 0.8.12",
  "toml_edit 0.21.0",
 ]
 
@@ -663,7 +664,7 @@ dependencies = [
  "os_info",
  "serde",
  "serde_derive",
- "toml 0.8.8",
+ "toml 0.8.12",
  "uuid",
 ]
 
@@ -1296,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -1521,15 +1522,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.0",
+ "toml_edit 0.22.9",
 ]
 
 [[package]]
@@ -1551,7 +1552,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.19",
 ]
 
 [[package]]
@@ -1564,7 +1565,20 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.19",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -1942,6 +1956,15 @@ name = "winnow"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/crates/huak-cli/Cargo.toml
+++ b/crates/huak-cli/Cargo.toml
@@ -28,6 +28,7 @@ openssl = { version = "0.10.57", features = ["vendored"], optional = true }
 pep508_rs.workspace = true
 termcolor.workspace = true
 thiserror.workspace = true
+toml = "0.8.12"
 url = "2.5.0"
 
 [dev-dependencies]

--- a/crates/huak-cli/tests/mod.rs
+++ b/crates/huak-cli/tests/mod.rs
@@ -34,6 +34,11 @@ mod tests {
     }
 
     #[test]
+    fn test_fix_freeze() {
+        assert_cmd_snapshot!(Command::new("huak").arg("freeze").arg("--help"));
+    }
+
+    #[test]
     fn test_fmt_help() {
         assert_cmd_snapshot!(Command::new("huak").arg("fmt").arg("--help"));
     }

--- a/crates/huak-cli/tests/mod.rs
+++ b/crates/huak-cli/tests/mod.rs
@@ -34,7 +34,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fix_freeze() {
+    fn test_freeze_help() {
         assert_cmd_snapshot!(Command::new("huak").arg("freeze").arg("--help"));
     }
 

--- a/crates/huak-cli/tests/snapshots/r#mod__tests__freeze_help.snap
+++ b/crates/huak-cli/tests/snapshots/r#mod__tests__freeze_help.snap
@@ -1,0 +1,23 @@
+---
+source: crates/huak_cli/tests/mod.rs
+info:
+  program: huak
+  args:
+    - freeze
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Add requirements.txt from pyproject.toml's dependencies
+
+Usage: huak freeze [OPTIONS]
+
+Options:
+  -n, --name <name>  Pass custom name of `requirements.txt`, by default it's `requirements.txt`
+  -q, --quiet        
+      --no-color     
+  -h, --help         Print help
+
+----- stderr -----
+

--- a/crates/huak-cli/tests/snapshots/r#mod__tests__help-2.snap
+++ b/crates/huak-cli/tests/snapshots/r#mod__tests__help-2.snap
@@ -20,6 +20,7 @@ Commands:
   completion  Generates a shell completion script for supported shells
   fix         Auto-fix fixable lint conflicts
   fmt         Format the project's Python code
+  freeze      Add requirements.txt from pyproject.toml's dependencies
   init        Initialize the current project
   install     Install a Python package (defaults to $HOME/.huak/bin)
   lint        Lint the project's Python code

--- a/crates/huak-cli/tests/snapshots/r#mod__tests__help.snap
+++ b/crates/huak-cli/tests/snapshots/r#mod__tests__help.snap
@@ -20,6 +20,7 @@ Commands:
   completion  Generates a shell completion script for supported shells
   fix         Auto-fix fixable lint conflicts
   fmt         Format the project's Python code
+  freeze      Add requirements.txt from pyproject.toml's dependencies
   init        Initialize the current project
   install     Install a Python package (defaults to $HOME/.huak/bin)
   lint        Lint the project's Python code


### PR DESCRIPTION
## Description

This PR is to add `freeze` command in `huak` so that it can create a `requirements.txt` file in the same directory as `pyproject.toml`.

## Usage
In a project with `pyproject.toml`:
```toml
[build-system]
requires = ["hatchling"]
build-backend = "hatchling.build"

[project]
name = "flet-demo"
version = "0.0.1"
description = ""
dependencies = [
    "flet ==0.21.2",
]

[project.optional-dependencies]
dev = [
    "build==1.2.1",
]

[tool.huak.task]
counter = "python3 src/flet_demo/counter.py"
todo = "python3 src/flet_demo/todo.py"
```

`$ huak freeze` works like this:
```sh
$ huak freeze
Dependencies extracted successfully.
```
with `requirements.txt` as:
```txt
flet==0.21.2
```

---

To create a custom file:

```sh
$ huak freeze -n deps.txt
Dependencies extracted successfully.
```
with `deps.txt` as:
```txt
flet==0.21.2
```
